### PR TITLE
Fix the issue where HTML generation causes JavaScript errors when dealing with multi-line comments.

### DIFF
--- a/src/main/java/com/power/doc/template/IDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/IDocBuildTemplate.java
@@ -85,11 +85,7 @@ public interface IDocBuildTemplate<T> {
             String name = DocUtil.generateId(apiDoc.getName());
             apiDoc.setAlias(name);
         }
-        String desc = "";
-        if(StringUtil.isNotEmpty(cls.getComment())){
-            desc = cls.getComment().replaceAll("<", "&lt;");
-            desc = desc.replaceAll(">", "&gt;");
-        }
+        String desc = DocUtil.getEscapeAndCleanComment(cls.getComment());
         apiDoc.setDesc(desc);
         apiDoc.setList(apiMethodDocs);
         apiDocList.add(apiDoc);

--- a/src/main/java/com/power/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/SpringBootDocBuildTemplate.java
@@ -90,7 +90,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc> {
             Collections.sort(apiDocList);
         } else if (setCustomOrder) {
             // while set custom oder
-           return apiDocList.stream()
+            return apiDocList.stream()
                     .sorted(Comparator.comparing(ApiDoc::getOrder))
                     .peek(p -> p.setOrder(atomicInteger.getAndAdd(1))).collect(Collectors.toList());
         }
@@ -141,7 +141,8 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc> {
             ApiMethodDoc apiMethodDoc = new ApiMethodDoc();
             apiMethodDoc.setOrder(methodOrder);
             apiMethodDoc.setName(method.getName());
-            apiMethodDoc.setDesc(method.getComment());
+            String comment = DocUtil.getEscapeAndCleanComment(method.getComment());
+            apiMethodDoc.setDesc(comment);
             String methodUid = DocUtil.generateId(clazName + method.getName());
             apiMethodDoc.setMethodId(methodUid);
             String apiNoteValue = DocUtil.getNormalTagComments(method, DocTags.API_NOTE, cls.getName());

--- a/src/main/java/com/power/doc/utils/DocUtil.java
+++ b/src/main/java/com/power/doc/utils/DocUtil.java
@@ -478,4 +478,19 @@ public class DocUtil {
                 return "object"; //array object file
         }
     }
+
+    /**
+     * Gets escape and clean comment.
+     *
+     * @param comment the comment
+     * @return the escape and clean comment
+     */
+    public static String getEscapeAndCleanComment(String comment) {
+        if (StringUtil.isEmpty(comment)) {
+            return "";
+        }
+        return comment.replaceAll("<", "&lt;")
+                .replaceAll(">", "&gt;")
+                .replaceAll(System.lineSeparator(), "");
+    }
 }

--- a/src/main/resources/template/Index.btl
+++ b/src/main/resources/template/Index.btl
@@ -64,7 +64,7 @@
         </nav>
     </div>
     <div id="book-body" class="book-body" height="100%">
-        <iframe src="${homePage}.html?v=${version}" frameborder="0" id="book_iframe" name="book_iframe" width="100%"></iframe>
+        <iframe src="${homePage}.html?v=${version}" frameborder="0" id="book_iframe" name="book_iframe" width="100%" height="100%"></iframe>
     </div>
 </div>
 


### PR DESCRIPTION
1. Add handling for line breaks in class and method comment content to prevent errors caused by line breaks within quotes in the generated HTML JavaScript.
2. Modify the iframe in the index to include height=100% to ensure that the full content is displayed even when there are JavaScript errors.