### PR TITLE
Add user-customized HTML and CSS template configuration.

### DIFF
--- a/src/main/java/com/power/doc/builder/DocBuilderTemplate.java
+++ b/src/main/java/com/power/doc/builder/DocBuilderTemplate.java
@@ -120,7 +120,12 @@ public class DocBuilderTemplate extends BaseDocBuilderTemplate {
         String strTime = DateTimeUtil.long2Str(now, DateTimeUtil.DATE_FORMAT_SECOND);
         FileUtil.mkdirs(outPath);
         List<ApiErrorCode> errorCodeList = errorCodeDictToList(config);
-        Template tpl = BeetlTemplateUtil.getByName(template);
+        Template tpl;
+        if (StringUtil.isEmpty(config.getCustomHtml())) {
+            tpl = BeetlTemplateUtil.getByName(template);
+        } else {
+            tpl = BeetlTemplateUtil.getByPath(config.getCustomHtml());
+        }
         String style = config.getStyle();
         tpl.binding(TemplateVariable.STYLE.getVariable(), style);
         tpl.binding(TemplateVariable.BACKGROUND.getVariable(), HighlightStyle.getBackgroundColor(style));

--- a/src/main/java/com/power/doc/builder/HtmlApiDocBuilder.java
+++ b/src/main/java/com/power/doc/builder/HtmlApiDocBuilder.java
@@ -23,6 +23,7 @@
 package com.power.doc.builder;
 
 import com.power.common.util.FileUtil;
+import com.power.common.util.StringUtil;
 import com.power.doc.model.ApiConfig;
 import com.power.doc.model.ApiDoc;
 import com.power.doc.template.IDocBuildTemplate;
@@ -74,8 +75,9 @@ public class HtmlApiDocBuilder {
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
         IDocBuildTemplate docBuildTemplate = new SpringBootDocBuildTemplate();
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder);
-        Template indexCssTemplate = BeetlTemplateUtil.getByName(ALL_IN_ONE_CSS);
-        FileUtil.nioWriteFile(indexCssTemplate.render(), config.getOutPath() + FILE_SEPARATOR + ALL_IN_ONE_CSS);
+
+        buildIndexCss(config.getCustomCss(), config.getOutPath());
+
         if (config.isAllInOne()) {
             if (StringUtils.isNotEmpty(config.getAllInOneDocFileName())) {
                 INDEX_HTML = config.getAllInOneDocFileName();
@@ -132,4 +134,22 @@ public class HtmlApiDocBuilder {
             index++;
         }
     }
+
+
+    /**
+     * build css
+     *
+     * @param customCss
+     * @param outPath
+     */
+    private static void buildIndexCss(String customCss, String outPath) {
+        Template indexCssTemplate;
+        if (StringUtil.isEmpty(customCss)) {
+            indexCssTemplate = BeetlTemplateUtil.getByName(ALL_IN_ONE_CSS);
+        } else {
+            indexCssTemplate = BeetlTemplateUtil.getByPath(customCss);
+        }
+        FileUtil.nioWriteFile(indexCssTemplate.render(), outPath + FILE_SEPARATOR + ALL_IN_ONE_CSS);
+    }
+
 }

--- a/src/main/java/com/power/doc/model/ApiConfig.java
+++ b/src/main/java/com/power/doc/model/ApiConfig.java
@@ -236,19 +236,22 @@ public class ApiConfig {
 
     /**
      * request ignore param
-     * @since 1.9.2
+     *
      * @return
+     * @since 1.9.2
      */
     private List<String> ignoreRequestParams;
 
     /**
      * display actual type of generic
+     *
      * @since 1.9.6
      */
     private boolean displayActualType;
 
     /**
      * Support Spring MVC ResponseBodyAdvice
+     *
      * @since 1.9.8
      */
     private ResponseBodyAdvice responseBodyAdvice;
@@ -259,6 +262,16 @@ public class ApiConfig {
      * create debug page
      */
     private boolean createDebugPage;
+
+    /**
+     * custom setting html template
+     */
+    private String customHtml;
+
+    /**
+     * custom setting css template
+     */
+    private String customCss;
 
     public String getServerUrl() {
         return serverUrl;
@@ -577,6 +590,22 @@ public class ApiConfig {
         this.createDebugPage = createDebugPage;
     }
 
+    public String getCustomHtml() {
+        return customHtml;
+    }
+
+    public void setCustomHtml(String customHtml) {
+        this.customHtml = customHtml;
+    }
+
+    public String getCustomCss() {
+        return customCss;
+    }
+
+    public void setCustomCss(String customCss) {
+        this.customCss = customCss;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("{");
@@ -656,6 +685,10 @@ public class ApiConfig {
                 .append(style).append('\"');
         sb.append(",\"createDebugPage\":")
                 .append(createDebugPage);
+        sb.append(",\"customHtml\":\"")
+                .append(customHtml).append('\"');
+        sb.append(",\"customCss\":")
+                .append(customCss);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/com/power/doc/utils/BeetlTemplateUtil.java
+++ b/src/main/java/com/power/doc/utils/BeetlTemplateUtil.java
@@ -27,6 +27,7 @@ import org.beetl.core.Configuration;
 import org.beetl.core.GroupTemplate;
 import org.beetl.core.Template;
 import org.beetl.core.resource.ClasspathResourceLoader;
+import org.beetl.core.resource.FileResourceLoader;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,6 +58,23 @@ public class BeetlTemplateUtil {
             return gt.getTemplate(templateName);
         } catch (IOException e) {
             throw new RuntimeException("Can't get Beetl template.");
+        }
+    }
+
+    /**
+     * Get Beetl template by file path(relative to the root path of your project)
+     *
+     * @param templatePath template path
+     * @return Beetl Template Object
+     */
+    public static Template getByPath(String templatePath) {
+        FileResourceLoader resourceLoader = new FileResourceLoader();
+        try {
+            Configuration cfg = Configuration.defaultConfiguration();
+            GroupTemplate gt = new GroupTemplate(resourceLoader, cfg);
+            return gt.getTemplate(templatePath);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't found Beetl template: " + resourceLoader.getRoot() + templatePath);
         }
     }
 
@@ -99,4 +117,5 @@ public class BeetlTemplateUtil {
             throw new RuntimeException("Can't found Beetl template.");
         }
     }
+
 }


### PR DESCRIPTION
Add user-customized HTML and CSS template configurations:

`customHtml`: Specify the path to the HTML template starting from the project root directory.
`customCss`: Specify the path to the CSS template starting from the project root directory.

User-customized templates can include their own logo, favicon, primary element colors, styles, etc.
It is very meaningful to display elements of one's own company when needing to provide them to third parties; it can also satisfy different user preference styles.
The inspiration comes from using Typora, where switching themes allows downloading CSS files from the market and loading them by placing them in a specified directory;
In the future, if smart-doc gains enough participants, we could also establish a theme marketplace (just a thought).