### PR TITLE
feat:添加支持Path前缀

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ When you need to use smart-doc to generate more API document information, you ca
 ```
 {
   "serverUrl": "http://127.0.0.1", // Set the server address, not required
+  "pathPrefix": "", //Set the path prefix,not required。eg: Servlet ContextPath
   "isStrict": false, // whether to enable strict mode
   "allInOne": true, // whether to merge documents into one file, generally recommended as true
   "outPath": "D: // md2", // Specify the output path of the document

--- a/README_CN.md
+++ b/README_CN.md
@@ -119,6 +119,7 @@ smart-doc官方目前已经开发完成[Maven插件](https://gitee.com/smart-doc
 ```
 {
   "serverUrl": "http://127.0.0.1", //服务器地址,非必须。导出postman建议设置成http://{{server}}方便直接在postman直接设置环境变量
+  "pathPrefix": "", //设置path前缀,非必须。如配置Servlet ContextPath
   "isStrict": false, //是否开启严格模式
   "allInOne": true,  //是否将文档合并到一个文件中，一般推荐为true
   "outPath": "D://md2", //指定文档的输出路径

--- a/src/main/java/com/power/doc/builder/OpenApiBuilder.java
+++ b/src/main/java/com/power/doc/builder/OpenApiBuilder.java
@@ -85,7 +85,7 @@ public class OpenApiBuilder {
         json.put("openapi", "3.0.3");
         json.put("info", buildInfo(config));
         json.put("servers", buildServers(config));
-        json.put("paths", buildPaths(apiDocList));
+        json.put("paths", buildPaths(config, apiDocList));
         json.put("components", buildComponentsSchema(apiDocList));
 
         String filePath = config.getOutPath();
@@ -127,7 +127,7 @@ public class OpenApiBuilder {
      * @param apiDocList api列表
      * @return
      */
-    private static Map<String, Object> buildPaths(List<ApiDoc> apiDocList) {
+    private static Map<String, Object> buildPaths(ApiConfig config, List<ApiDoc> apiDocList) {
         Map<String, Object> pathMap = new HashMap<>(500);
         apiDocList.forEach(
                 a -> {
@@ -135,7 +135,7 @@ public class OpenApiBuilder {
                     apiMethodDocs.forEach(
                             method -> {
                                 //设置paths的请求url 将双斜杠替换成单斜杠
-                                String url = method.getPath().replace("//", "/");
+                                String url = (config.getPathPrefix() + "/" + method.getPath()).replace("//", "/");
                                 Map<String, Object> request = buildPathUrls(method, a);
                                 //pathMap.put(method.getPath().replace("//", "/"), buildPathUrls(method, a));
                                 if (!pathMap.containsKey(url)) {

--- a/src/main/java/com/power/doc/model/ApiConfig.java
+++ b/src/main/java/com/power/doc/model/ApiConfig.java
@@ -44,6 +44,11 @@ public class ApiConfig {
     private String serverUrl;
 
     /**
+     * Path Prefix, eg: Servlet ContextPath
+     */
+    private String pathPrefix;
+
+    /**
      * Set comments check mode
      */
     private boolean isStrict;
@@ -336,6 +341,14 @@ public class ApiConfig {
      * smart-doc supported framework, if not set default is spring,
      */
     private String framework;
+
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    public void setPathPrefix(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+    }
 
     public String getAuthor() {
         return author;


### PR DESCRIPTION
SmartDoc 生成的OpenAPI json 文件，提供Path自定义的前缀支持。
如在springboot 项目中配置了server.servlet.context-path，理想状况生成的Path的路径应该是：server.servlet.context-path + controller 类对应的RequestMapping的value + 类方法的RequestMapping的value，改动内容：
- com.power.doc.model.ApiConfig 添加pathPrefix属性及get,set方法
- com.power.doc.builder.OpenApiBuilder#buildPaths 方法参数添加ApiConfig,url 计算做改动
- readme.md两个文件添加pathPrefix描述