### PR TITLE
[spencer]fix not all source scan into javaProjectBuilder.

### DIFF
--- a/src/main/java/com/power/doc/builder/ProjectDocConfigBuilder.java
+++ b/src/main/java/com/power/doc/builder/ProjectDocConfigBuilder.java
@@ -30,9 +30,13 @@ import com.power.doc.constants.HighlightStyle;
 import com.power.doc.model.*;
 import com.power.doc.utils.JavaClassUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
+import com.thoughtworks.qdox.directorywalker.DirectoryScanner;
+import com.thoughtworks.qdox.directorywalker.SuffixFilter;
 import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.parser.ParseException;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -120,10 +124,22 @@ public class ProjectDocConfigBuilder {
                 String strPath = path.getPath();
                 if (StringUtil.isNotEmpty(strPath)) {
                     strPath = strPath.replace("\\", "/");
-                    builder.addSourceTree(new File(strPath));
+                    loadJavaSource(strPath, builder);
                 }
             }
         }
+    }
+
+    private void loadJavaSource(String strPath, JavaProjectBuilder builder){
+        DirectoryScanner scanner = new DirectoryScanner(new File(strPath));
+        scanner.addFilter(new SuffixFilter(".java"));
+        scanner.scan(currentFile -> {
+            try {
+                builder.addSource(currentFile);
+            } catch (ParseException | IOException e) {
+                log.warning(e.getMessage());
+            }
+        });
     }
 
     private void initClassFilesMap() {

--- a/src/test/java/com/power/doc/qbox/QboxScanSourceTest.java
+++ b/src/test/java/com/power/doc/qbox/QboxScanSourceTest.java
@@ -1,0 +1,48 @@
+package com.power.doc.qbox;
+
+import com.power.doc.builder.HtmlApiDocBuilder;
+import com.power.doc.constants.FrameworkEnum;
+import com.power.doc.model.ApiConfig;
+import com.power.doc.model.SourceCodePath;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+/**
+ * smart-doc
+ *
+ * @author spencer
+ * @project smart-doc
+ * @date 2022-01-2022/1/13
+ */
+public class QboxScanSourceTest {
+
+    @Test
+    public void scanError() {
+        // target source folder for scan
+        String testJavaDirectory = Paths.get("src", "test", "java").toAbsolutePath().toString();
+        String outPath = Paths.get("target").toAbsolutePath().toString();
+
+        // config and scan
+        ApiConfig config = new ApiConfig();
+        config.setServerUrl("HSF://127.0.0.1:8088");
+        config.setOpenUrl("http://demo.torna.cn/api");
+        config.setDebugEnvName("测试环境");
+        config.setStyle("randomLight");
+        config.setCreateDebugPage(true);
+        config.setAuthor("test");
+        config.setDebugEnvUrl("HSF://127.0.0.1");
+        config.setCreateDebugPage(false);
+        config.setAllInOne(true);
+        config.setOutPath(outPath);
+        config.setMd5EncryptedHtmlName(true);
+        config.setFramework(FrameworkEnum.DUBBO.getFramework());
+        config.setSourceCodePaths(
+                SourceCodePath.builder().setDesc("tesSourceScan")
+                        .setPath(testJavaDirectory));
+
+        // This bug caused not all source code to be found.
+        // error at ProjectDocConfigBuilder#loadJavaSource when qbox parse ScanErrorSource
+        HtmlApiDocBuilder.buildApiDoc(config);
+    }
+}

--- a/src/test/java/com/power/doc/qbox/ScanErrorSource.java
+++ b/src/test/java/com/power/doc/qbox/ScanErrorSource.java
@@ -1,0 +1,13 @@
+package com.power.doc.qbox;
+
+/**
+ * qbox scan error
+ */
+public class ScanErrorSource {
+
+
+    protected void record(Object invasionDto, String aggregationType, String aggregationName, Long taskId) {
+
+    }
+
+}


### PR DESCRIPTION
bugfix: This PR fixes some APIs not being scanned into JavaProjectBuilder when parsing a java file fails.
junit: errorDemo in QboxScanSourceTest.