### PR TITLE
Adjust Solon framework adaptation: Add support for Remoting annotations.

### DIFF
--- a/src/main/java/com/power/doc/constants/SolonAnnotations.java
+++ b/src/main/java/com/power/doc/constants/SolonAnnotations.java
@@ -22,6 +22,9 @@ public interface SolonAnnotations {
     String REQUEST_PARAM = "Param";
     String REQUEST_PARAM_FULL = "org.noear.solon.annotation.Param";
 
+    String PATH_VAR = "PathVar";
+    String PATH_VAR_FULL = "org.noear.solon.annotation.PathVar";
+
     String REQUEST_HERDER = "Header";
     String REQUEST_HERDER_FULL = "org.noear.solon.annotation.Header";
 
@@ -31,9 +34,12 @@ public interface SolonAnnotations {
     String CONTROLLER = "Controller";
     String CONTROLLER_FULL = "org.noear.solon.annotation.Controller";
 
+    String COMPONENT = "Component";
+    String COMPONENT_FULL = "org.noear.solon.annotation.Component";
+
+    String REMOTING = "Remoting";
+    String REMOTING_FULL = "org.noear.solon.annotation.Remoting";
+
     String MODE_AND_VIEW_FULLY = "org.noear.solon.core.handle.ModelAndView";
 
-
-    String PATH_VAR = "PathVar";
-    String PATH_VAR_FULL = "org.noear.solon.annotation.PathVar";
 }

--- a/src/main/java/com/power/doc/template/SolonDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/SolonDocBuildTemplate.java
@@ -976,7 +976,8 @@ public class SolonDocBuildTemplate implements IDocBuildTemplate<ApiDoc> {
         classAnnotations.addAll(cls.getAnnotations());
         for (JavaAnnotation annotation : classAnnotations) {
             String name = annotation.getType().getValue();
-            if (SolonAnnotations.CONTROLLER.equals(name)) {
+            if (SolonAnnotations.CONTROLLER.equals(name) ||
+                    SolonAnnotations.REMOTING.equals(name)) {
                 return true;
             }
         }

--- a/src/main/resources/template/ApiDoc.adoc
+++ b/src/main/resources/template/ApiDoc.adoc
@@ -63,7 +63,7 @@ for(param in doc.queryParams){
 <%}%>
 
 <%if(isNotEmpty(doc.requestParams)){%>
-*Request-parameters:*
+*Body-parameters:*
 
 [width="100%",options="header"]
 [stripes=even]


### PR DESCRIPTION
1. Add support for Remoting annotations.
2. Change "Request-parameters" to "Body-parameters" in the ApiDoc.adoc template file.