### PR TITLE
Added a "solution" analysis for error codes & data dictionaries also support custom parsers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>smart-doc</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.1</version>
+    <version>2.5.1.1</version>
 
     <name>smart-doc</name>
     <url>https://github.com/smart-doc-group/smart-doc.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>smart-doc</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.1.1</version>
+    <version>2.5.1</version>
 
     <name>smart-doc</name>
     <url>https://github.com/smart-doc-group/smart-doc.git</url>

--- a/src/main/java/com/power/doc/model/ApiDataDictionary.java
+++ b/src/main/java/com/power/doc/model/ApiDataDictionary.java
@@ -59,6 +59,11 @@ public class ApiDataDictionary {
     private String enumClassName;
 
     /**
+     * customized values resolve class
+     */
+    private String valuesResolverClass;
+
+    /**
      * code field
      */
     private String codeField;
@@ -127,6 +132,16 @@ public class ApiDataDictionary {
 
     public ApiDataDictionary setEnumClassName(String enumClassName) {
         this.enumClassName = enumClassName;
+        return this;
+    }
+
+
+    public String getValuesResolverClass() {
+        return valuesResolverClass;
+    }
+
+    public ApiDataDictionary setValuesResolverClass(String valuesResolverClass) {
+        this.valuesResolverClass = valuesResolverClass;
         return this;
     }
 

--- a/src/main/java/com/power/doc/model/ApiErrorCode.java
+++ b/src/main/java/com/power/doc/model/ApiErrorCode.java
@@ -31,4 +31,13 @@ import com.power.common.model.EnumDictionary;
  * @author yu 2018/06/25.
  */
 public class ApiErrorCode extends EnumDictionary {
+    private String solution;
+
+    public String getSolution() {
+        return this.solution;
+    }
+
+    public void setSolution(String solution) {
+        this.solution = solution;
+    }
 }

--- a/src/main/java/com/power/doc/utils/TornaUtil.java
+++ b/src/main/java/com/power/doc/utils/TornaUtil.java
@@ -220,10 +220,10 @@ public class TornaUtil {
         CommonErrorCode commonErrorCode;
         List<ApiErrorCode> errorCodes = DocUtil.errorCodeDictToList(config, javaProjectBuilder);
         if (CollectionUtil.isNotEmpty(errorCodes)) {
-            for (EnumDictionary code : errorCodes) {
+            for (ApiErrorCode code : errorCodes) {
                 commonErrorCode = new CommonErrorCode();
                 commonErrorCode.setCode(code.getValue());
-                // commonErrorCode.setSolution(code.getDesc());
+                commonErrorCode.setSolution(DocUtil.replaceNewLineToHtmlBr(code.getSolution()));
                 commonErrorCode.setMsg(DocUtil.replaceNewLineToHtmlBr(code.getDesc()));
                 commonErrorCodes.add(commonErrorCode);
             }


### PR DESCRIPTION
Error codes are typically composed of three parts:
- Code
- Description
- Solution
Currently, the `com.power.doc.model.ApiErrorCode` does not have a field for the "solution." This field is specifically added to facilitate the display of corresponding information on platforms like Torna.