### PR TITLE
fix #393

### DIFF
--- a/src/main/java/com/power/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/power/doc/helper/ParamsBuildHelper.java
@@ -233,6 +233,9 @@ public class ParamsBuildHelper extends BaseHelper {
                             strRequired = true;
                         }
                     }
+                    if (JavaClassValidateUtil.isJSR303Required(simpleAnnotationName) && isResp) {
+                        strRequired = true;
+                    }
                 }
                 comment.append(JavaFieldUtil.getJsrComment(javaAnnotations));
                 String fieldValue = BaseHelper.getFieldValueFromMock(subTypeName, tagsMap, typeSimpleName);

--- a/src/main/java/com/power/doc/template/IBaseDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/IBaseDocBuildTemplate.java
@@ -111,7 +111,7 @@ public interface IBaseDocBuildTemplate {
                     docJavaMethod.setReturnSchema(OpenApiSchemaUtil.arrayTypeSchema(gicName));
                     return new ArrayList<>(0);
                 }
-                 return ParamsBuildHelper.buildParams(gicName, "", 0, null, Boolean.TRUE,
+                 return ParamsBuildHelper.buildParams(gicName, "", 0, "true", Boolean.TRUE,
                     new HashMap<>(), projectBuilder, null, 0, Boolean.FALSE, null);
             } else {
                 return new ArrayList<>(0);
@@ -122,11 +122,11 @@ public interface IBaseDocBuildTemplate {
             if (keyValue.length == 0) {
                 return new ArrayList<>(0);
             }
-            return ParamsBuildHelper.buildParams(returnType, "", 0, null, Boolean.TRUE,
+            return ParamsBuildHelper.buildParams(returnType, "", 0, "true", Boolean.TRUE,
                 new HashMap<>(), projectBuilder, null, 0, Boolean.FALSE, null);
         }
         if (StringUtil.isNotEmpty(returnType)) {
-            return ParamsBuildHelper.buildParams(returnType, "", 0, null, Boolean.TRUE,
+            return ParamsBuildHelper.buildParams(returnType, "", 0, "true", Boolean.TRUE,
                 new HashMap<>(), projectBuilder, null, 0, Boolean.FALSE, null);
         }
         return new ArrayList<>(0);


### PR DESCRIPTION
buildComponentSchema函数依次将请求参数和返回参数中的Schema添加到compnent中，但如果返回参数和请求参数使用了相同的Schema，则会出现覆盖。
如果Schema一致，覆盖也无影响，但返回参数中的Schema却没有require字段，这是bug产生的原因。
如果要返回参数存在require字段，一是buildReturnApiParams需要以isRequired参数非空的方式调用buildParams,二是buildParam需要检查返回参数的JSR303注解。修改后即可正确生成Schema。
除了这个方法，也可以修改openApiGreate避免Schema覆盖，但个人认为返回参数的required字段还是比较重要的，可以判断返回结果正确与否。
因此，希望官方增加返回参数的required字段。