### PR TITLE
Add a class parameter to DictionaryValuesResolver.

### DIFF
--- a/src/main/java/com/power/doc/extension/dict/DictionaryValuesResolver.java
+++ b/src/main/java/com/power/doc/extension/dict/DictionaryValuesResolver.java
@@ -22,14 +22,37 @@
  */
 package com.power.doc.extension.dict;
 
-import java.util.Collection;
-
 import com.power.common.model.EnumDictionary;
 
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+
 /**
- * https://github.com/smart-doc-group/smart-doc/issues/338
+ * @see <a href="https://github.com/smart-doc-group/smart-doc/issues/338">issues-338</a>
  */
 public interface DictionaryValuesResolver {
 
-    <T extends EnumDictionary> Collection<T> resolve();
+    /**
+     * resolve the dictionary, if an exception occurs, return empty collection instead of null
+     * default behaviour is the same as {@link #resolve()}
+     *
+     * @param clazz dictionary class
+     * @return the dictionary
+     */
+    @Nonnull
+    default <T extends EnumDictionary> Collection<T> resolve(@Nonnull Class<?> clazz) {
+        return resolve();
+    }
+
+    /**
+     * resolve the dictionary, for compatibility, do not return null
+     *
+     * @see #resolve(Class)
+     */
+    @Nonnull
+    default <T extends EnumDictionary> Collection<T> resolve() {
+        return Collections.emptyList();
+    }
+
 }

--- a/src/main/java/com/power/doc/model/ApiErrorCode.java
+++ b/src/main/java/com/power/doc/model/ApiErrorCode.java
@@ -24,6 +24,8 @@ package com.power.doc.model;
 
 import com.power.common.model.EnumDictionary;
 
+import java.util.Objects;
+
 /**
  * Description:
  * restful api error code
@@ -32,4 +34,21 @@ import com.power.common.model.EnumDictionary;
  */
 public class ApiErrorCode extends EnumDictionary {
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue(), getType(), getDesc(), getOrdinal(), getName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ApiErrorCode)) {
+            return false;
+        }
+        ApiErrorCode other = (ApiErrorCode) obj;
+        return Objects.equals(getValue(), other.getValue()) &&
+                Objects.equals(getType(), other.getType()) &&
+                Objects.equals(getDesc(), other.getDesc()) &&
+                Objects.equals(getOrdinal(), other.getOrdinal()) &&
+                Objects.equals(getName(), other.getName());
+    }
 }

--- a/src/main/java/com/power/doc/utils/DocUtil.java
+++ b/src/main/java/com/power/doc/utils/DocUtil.java
@@ -22,74 +22,31 @@
  */
 package com.power.doc.utils;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Stack;
-import java.util.UUID;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import com.mifmif.common.regex.Generex;
-import com.power.common.util.CollectionUtil;
-import com.power.common.util.DateTimeUtil;
-import com.power.common.util.EnumUtil;
-import com.power.common.util.IDCardUtil;
-import com.power.common.util.RandomUtil;
-import com.power.common.util.StringUtil;
-import com.power.doc.constants.DocAnnotationConstants;
-import com.power.doc.constants.DocGlobalConstants;
-import com.power.doc.constants.DocTags;
-import com.power.doc.constants.JAXRSAnnotations;
-import com.power.doc.constants.JakartaJaxrsAnnotations;
+import com.power.common.util.*;
+import com.power.doc.constants.*;
 import com.power.doc.extension.dict.DictionaryValuesResolver;
-import com.power.doc.model.ApiConfig;
-import com.power.doc.model.ApiDataDictionary;
-import com.power.doc.model.ApiDocDict;
-import com.power.doc.model.ApiErrorCode;
-import com.power.doc.model.ApiErrorCodeDictionary;
-import com.power.doc.model.ApiReqParam;
-import com.power.doc.model.DataDict;
-import com.power.doc.model.DocJavaField;
-import com.power.doc.model.FormData;
-import com.power.doc.model.SystemPlaceholders;
+import com.power.doc.model.*;
 import com.power.doc.model.request.RequestMapping;
 import com.thoughtworks.qdox.JavaProjectBuilder;
-import com.thoughtworks.qdox.model.DocletTag;
-import com.thoughtworks.qdox.model.JavaAnnotation;
-import com.thoughtworks.qdox.model.JavaClass;
-import com.thoughtworks.qdox.model.JavaField;
-import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.*;
 import com.thoughtworks.qdox.model.expression.Add;
 import com.thoughtworks.qdox.model.expression.AnnotationValue;
 import com.thoughtworks.qdox.model.expression.Expression;
 import com.thoughtworks.qdox.model.expression.FieldRef;
-
+import net.datafaker.Faker;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import net.datafaker.Faker;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.power.doc.constants.DocGlobalConstants.JSON_CONTENT_TYPE;
 import static com.power.doc.constants.DocGlobalConstants.NO_COMMENTS_FOUND;
-import static com.power.doc.model.SystemPlaceholders.PLACEHOLDER_PREFIX;
-import static com.power.doc.model.SystemPlaceholders.PLACEHOLDER_SUFFIX;
-import static com.power.doc.model.SystemPlaceholders.SIMPLE_PREFIX;
-import static com.power.doc.model.SystemPlaceholders.hasSystemProperties;
+import static com.power.doc.model.SystemPlaceholders.*;
 
 /**
  * Description:
@@ -435,8 +392,8 @@ public class DocUtil {
             String value = docletTag.getValue();
             if (StringUtil.isEmpty(value) && StringUtil.isNotEmpty(className)) {
                 throw new RuntimeException("ERROR: #" + javaMethod.getName()
-                    + "() - bad @" + tagName + " javadoc from " + javaMethod.getDeclaringClass()
-                    .getCanonicalName() + ", This is an invalid comment.");
+                        + "() - bad @" + tagName + " javadoc from " + javaMethod.getDeclaringClass()
+                        .getCanonicalName() + ", This is an invalid comment.");
             }
             if (DocTags.PARAM.equals(tagName)) {
                 String pName = value;
@@ -449,7 +406,7 @@ public class DocUtil {
                 }
                 if ("|".equals(StringUtil.trim(pValue)) && StringUtil.isNotEmpty(className)) {
                     throw new RuntimeException("ERROR: An invalid comment was written [@" + tagName + " |]," +
-                        "Please @see " + javaMethod.getDeclaringClass().getCanonicalName() + "." + javaMethod.getName() + "()");
+                            "Please @see " + javaMethod.getDeclaringClass().getCanonicalName() + "." + javaMethod.getName() + "()");
                 }
                 paramTagMap.put(pName, pValue);
             } else {
@@ -485,7 +442,7 @@ public class DocUtil {
             paramTags = docJavaField.getDocletTags();
         }
         return paramTags.stream().collect(Collectors.toMap(DocletTag::getName, DocletTag::getValue,
-            (key1, key2) -> key1 + "," + key2));
+                (key1, key2) -> key1 + "," + key2));
     }
 
     /**
@@ -677,7 +634,7 @@ public class DocUtil {
             return "";
         }
         return comment.replaceAll("<", "&lt;")
-            .replaceAll(">", "&gt;");
+                .replaceAll(">", "&gt;");
     }
 
     /**
@@ -788,8 +745,9 @@ public class DocUtil {
                     }
                     if (null != valuesResolverClass && DictionaryValuesResolver.class.isAssignableFrom(valuesResolverClass)) {
                         DictionaryValuesResolver resolver = (DictionaryValuesResolver) DocClassUtil.newInstance(valuesResolverClass);
-                        Collection<ApiErrorCode> enumDictionaries = resolver.resolve();
-                        errorCodeList.addAll(enumDictionaries);
+                        // add two method results
+                        errorCodeList.addAll(resolver.resolve());
+                        errorCodeList.addAll(resolver.resolve(clzz));
                     } else if (clzz.isInterface()) {
                         Set<Class<? extends Enum>> enumImplementSet = dictionary.getEnumImplementSet();
                         if (CollectionUtil.isEmpty(enumImplementSet)) {
@@ -802,7 +760,7 @@ public class DocUtil {
                                 continue;
                             }
                             List<ApiErrorCode> enumDictionaryList = EnumUtil.getEnumInformation(enumClass, dictionary.getCodeField(),
-                                dictionary.getDescField());
+                                    dictionary.getDescField());
                             errorCodeList.addAll(enumDictionaryList);
                         }
 
@@ -812,7 +770,7 @@ public class DocUtil {
                             continue;
                         }
                         List<ApiErrorCode> enumDictionaryList = EnumUtil.getEnumInformation(clzz, dictionary.getCodeField(),
-                            dictionary.getDescField());
+                                dictionary.getDescField());
                         errorCodeList.addAll(enumDictionaryList);
                     }
 
@@ -867,9 +825,9 @@ public class DocUtil {
                         apiDocDict.setOrder(order++);
                         apiDocDict.setTitle(javaClass.getComment());
                         apiDocDict.setDescription(
-                            DocUtil.getEscapeAndCleanComment(Optional.ofNullable(apiNoteTag).map(DocletTag::getValue).orElse(StringUtil.EMPTY)));
+                                DocUtil.getEscapeAndCleanComment(Optional.ofNullable(apiNoteTag).map(DocletTag::getValue).orElse(StringUtil.EMPTY)));
                         List<DataDict> enumDictionaryList = EnumUtil.getEnumInformation(enumClass, apiDataDictionary.getCodeField(),
-                            apiDataDictionary.getDescField());
+                                apiDataDictionary.getDescField());
                         apiDocDict.setDataDictList(enumDictionaryList);
                         apiDocDictList.add(apiDocDict);
                     }
@@ -884,12 +842,12 @@ public class DocUtil {
                     }
                     DocletTag apiNoteTag = javaClass.getTagByName(DocTags.API_NOTE);
                     apiDocDict.setDescription(
-                        DocUtil.getEscapeAndCleanComment(Optional.ofNullable(apiNoteTag).map(DocletTag::getValue).orElse(StringUtil.EMPTY)));
+                            DocUtil.getEscapeAndCleanComment(Optional.ofNullable(apiNoteTag).map(DocletTag::getValue).orElse(StringUtil.EMPTY)));
                     if (apiDataDictionary.getTitle() == null) {
                         apiDocDict.setTitle(javaClass.getComment());
                     }
                     List<DataDict> enumDictionaryList = EnumUtil.getEnumInformation(clazz, apiDataDictionary.getCodeField(),
-                        apiDataDictionary.getDescField());
+                            apiDataDictionary.getDescField());
                     if (!clazz.isEnum()) {
                         throw new RuntimeException(clazz.getCanonicalName() + " is not an enum class.");
                     }
@@ -938,10 +896,10 @@ public class DocUtil {
 
     public static String handleContentType(String mediaType, JavaAnnotation annotation, String annotationName) {
         if (JakartaJaxrsAnnotations.JAX_PRODUCES_FULLY.equals(annotationName)
-            || JAXRSAnnotations.JAX_PRODUCES_FULLY.equals(annotationName)) {
+                || JAXRSAnnotations.JAX_PRODUCES_FULLY.equals(annotationName)) {
             String annotationValue = StringUtil.removeQuotes(DocUtil.getRequestHeaderValue(annotation));
             if ("MediaType.APPLICATION_JSON".equals(annotationValue) || "application/json".equals(annotationValue)
-                || "MediaType.TEXT_PLAIN".equals(annotationValue) || "text/plain".equals(annotationValue)) {
+                    || "MediaType.TEXT_PLAIN".equals(annotationValue) || "text/plain".equals(annotationValue)) {
                 mediaType = JSON_CONTENT_TYPE;
             }
         }
@@ -950,11 +908,11 @@ public class DocUtil {
 
     public static boolean filterPath(RequestMapping requestMapping, ApiReqParam apiReqHeader) {
         if (StringUtil.isEmpty(apiReqHeader.getPathPatterns())
-            && StringUtil.isEmpty(apiReqHeader.getExcludePathPatterns())) {
+                && StringUtil.isEmpty(apiReqHeader.getExcludePathPatterns())) {
             return true;
         }
         return DocPathUtil.matches(requestMapping.getShortUrl(), apiReqHeader.getPathPatterns()
-            , apiReqHeader.getExcludePathPatterns());
+                , apiReqHeader.getExcludePathPatterns());
 
     }
 
@@ -992,7 +950,7 @@ public class DocUtil {
                 }
                 if (!visitedPlaceholders.add(originalPlaceholder)) {
                     throw new IllegalArgumentException(
-                        "Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
+                            "Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
                 }
                 // Recursive invocation, parsing placeholders contained in the placeholder key.
                 placeholder = delPropertiesUrl(placeholder, visitedPlaceholders);

--- a/src/main/java/com/power/doc/utils/DocUtil.java
+++ b/src/main/java/com/power/doc/utils/DocUtil.java
@@ -728,7 +728,7 @@ public class DocUtil {
             return new ArrayList<>(0);
         } else {
             ClassLoader classLoader = config.getClassLoader();
-            List<ApiErrorCode> errorCodeList = new ArrayList<>();
+            Set<ApiErrorCode> errorCodeList = new HashSet<>();
             try {
                 for (ApiErrorCodeDictionary dictionary : errorCodeDictionaries) {
                     Class<?> clzz = dictionary.getEnumClass();
@@ -778,7 +778,7 @@ public class DocUtil {
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }
-            return errorCodeList;
+            return new ArrayList<>(errorCodeList);
         }
     }
 


### PR DESCRIPTION
## Summary (Description of this PR)
Add a method `com.power.doc.extension.dict.DictionaryValuesResolver#resolve(Class)`
Use the `javax.annotation.Nonnull` annotation for several parameters and return values in DictionaryValuesResolver
### Basic Example (PR Use Case)
```java
public class BaseExceptionValuesResolver implements DictionaryValuesResolver {

    @NotNull
    @Override
    @SuppressWarnings("unchecked")
    public <T extends EnumDictionary> Collection<T> resolve(@NotNull Class<?> clazz) {
        return (Collection<T>) Arrays.stream(clazz.getDeclaredFields())
                .map(it -> fieldMapper(it, clazz))
                .filter(Objects::nonNull)
                .collect(Collectors.toList());
    }

    private EnumDictionary fieldMapper(Field field, Class<?> codeClass) {
        try {
            if (IAssert.class.isAssignableFrom(field.getType())) {
                IAssert anAssert = (IAssert) field.get(codeClass);
                return EnumDictionary.builder()
                        .setName(field.getName())
                        .setDesc(anAssert.getMsg())
                        .setValue(String.valueOf(anAssert.getCode()));
            }
        } catch (Exception e) {
            e.printStackTrace();
        }
        return null;
    }

}
```

### Motivation (Purpose of this PR)
Since we have already set `valuesResolverClass`, there is still a need to set `enumClassName`. Why not add the class obtained from `enumClassName` as a parameter in the DictionaryValuesResolver interface? Otherwise, being tied to a configuration feels uncomfortable.
### Appendix: Not setting `enumClassName` will lead to NPE
```java
java.lang.NullPointerException: Cannot invoke "java.lang.Class.isInterface()" because "enumClass" is null
    at com.power.doc.builder.ProjectDocConfigBuilder.getEnumImplementsByInterface (ProjectDocConfigBuilder.java:146)
    at com.power.doc.builder.ProjectDocConfigBuilder.initDict (ProjectDocConfigBuilder.java:141)
    at com.power.doc.builder.ProjectDocConfigBuilder.<init> (ProjectDocConfigBuilder.java:117)
    at com.power.doc.builder.ApiDocBuilder.buildApiDoc (ApiDocBuilder.java:72)
    at com.smartdoc.mojo.MarkDownMojo.executeMojo (MarkDownMojo.java:44)
    at com.smartdoc.mojo.BaseDocsGeneratorMojo.execute (BaseDocsGeneratorMojo.java:158)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:210)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:195)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
```