### PR TITLE
Fix bug: The issue where ${} in some url/shorturl/path was not correctly resolved.

### DIFF
--- a/src/main/java/com/power/doc/handler/IRequestMappingHandler.java
+++ b/src/main/java/com/power/doc/handler/IRequestMappingHandler.java
@@ -60,6 +60,7 @@ public interface IRequestMappingHandler {
             url = UrlUtil.simplifyUrl(StringUtil.trim(url)) + urlSuffix;
             shortUrl = UrlUtil.simplifyUrl(StringUtil.trim(shortUrl)) + urlSuffix;
             url = DocUtil.formatPathUrl(url);
+            shortUrl = DocUtil.formatPathUrl(shortUrl);
             requestMapping.setUrl(url).setShortUrl(shortUrl);
             return requestMapping;
         }

--- a/src/main/java/com/power/doc/utils/DocUtil.java
+++ b/src/main/java/com/power/doc/utils/DocUtil.java
@@ -968,7 +968,7 @@ public class DocUtil {
                 }
                 if (propVal != null) {
                     propVal = delPropertiesUrl(propVal, visitedPlaceholders);
-                    result.replace(startIndex, endIndex + PLACEHOLDER_PREFIX.length(), propVal);
+                    result.replace(startIndex-1, endIndex + PLACEHOLDER_PREFIX.length()-1, propVal);
                     startIndex = result.indexOf(PLACEHOLDER_PREFIX, startIndex + propVal.length());
                 } else {
                     // Proceed with unprocessed value.


### PR DESCRIPTION
1. Bug fixed: The position of ${} in url replacement was off by one position.
2. Bug fixed: ${} in path (shorturl) was not resolved; in tornado, the path calls the shorturl, and this bug also fixed the issue of unresolved ${} in paths within tornado.