### PR TITLE
[Fix] OpenApiTag did not override equals and hashCode, causing the HashSet to fail in deduplication. The operationId failed due to request path and type...

### DIFF
--- a/src/main/java/com/power/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/power/doc/builder/openapi/OpenApiBuilder.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.FileUtil;
@@ -44,6 +45,7 @@ import com.power.doc.model.openapi.OpenApiTag;
 import com.power.doc.utils.JsonUtil;
 import com.power.doc.utils.OpenApiSchemaUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
+import org.apache.commons.lang3.StringUtils;
 
 import static com.power.doc.constants.DocGlobalConstants.*;
 
@@ -151,8 +153,10 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
         request.put("parameters", buildParameters(apiMethodDoc));
         request.put("responses", buildResponses(apiConfig, apiMethodDoc));
         request.put("deprecated", apiMethodDoc.isDeprecated());
-        String operationId = apiMethodDoc.getUrl().replace(apiMethodDoc.getServerUrl(), "");
-        request.put("operationId", String.join("", OpenApiSchemaUtil.getPatternResult("[A-Za-z0-9{}]*", operationId)));
+        List<String> paths = OpenApiSchemaUtil.getPatternResult("[A-Za-z0-9_{}]*", apiMethodDoc.getPath());
+        paths.add(apiMethodDoc.getType());
+        String operationId = paths.stream().filter(StringUtils::isNotEmpty).collect(Collectors.joining("-"));
+        request.put("operationId", operationId);
 
         return request;
     }

--- a/src/main/java/com/power/doc/model/openapi/OpenApiTag.java
+++ b/src/main/java/com/power/doc/model/openapi/OpenApiTag.java
@@ -1,5 +1,7 @@
 package com.power.doc.model.openapi;
 
+import java.util.Objects;
+
 /**
  * open api tag
  *
@@ -44,5 +46,18 @@ public class OpenApiTag {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OpenApiTag that = (OpenApiTag) o;
+        return Objects.equals(getName(), that.getName()) && Objects.equals(getDescription(), that.getDescription());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getDescription());
     }
 }


### PR DESCRIPTION
[Fix] OpenApiTag did not override equals and hashCode, causing the HashSet to fail in deduplication. The operationId failed due to request path and type...