### PR TITLE
The `packageFilters` parameter supports method-level granularity.

### DIFF
--- a/src/main/java/com/power/doc/constants/DocGlobalConstants.java
+++ b/src/main/java/com/power/doc/constants/DocGlobalConstants.java
@@ -258,4 +258,6 @@ public interface DocGlobalConstants {
     String SWAGGER_FILE_TAG = "formData";
 
     String OPENAPI_TAG = "default";
+
+    String DEFAULT_FILTER_METHOD = "*";
 }

--- a/src/main/java/com/power/doc/template/JaxrsDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/JaxrsDocBuildTemplate.java
@@ -84,7 +84,7 @@ public class JaxrsDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IRestDo
         for (JavaClass cls : classes) {
             if (StringUtil.isNotEmpty(apiConfig.getPackageFilters())) {
                 // from smart config
-                if (!DocUtil.isMatch(apiConfig.getPackageFilters(), cls.getCanonicalName())) {
+                if (!DocUtil.isMatch(apiConfig.getPackageFilters(), cls)) {
                     continue;
                 }
             }
@@ -147,6 +147,9 @@ public class JaxrsDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IRestDo
             }
         }
 
+        Set<String> filterMethods = DocUtil.findFilterMethods(clzName);
+        boolean needAllMethods = filterMethods.contains(DocGlobalConstants.DEFAULT_FILTER_METHOD);
+
         List<JavaMethod> methods = cls.getMethods();
         List<DocJavaMethod> docJavaMethods = new ArrayList<>(methods.size());
         // filter  private method
@@ -154,7 +157,9 @@ public class JaxrsDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IRestDo
             if (method.isPrivate()) {
                 continue;
             }
-            docJavaMethods.add(convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
+            if (needAllMethods || filterMethods.contains(method.getName())) {
+                docJavaMethods.add(convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
+            }
         }
         // add parent class methods
         docJavaMethods.addAll(getParentsClassMethods(apiConfig, projectBuilder, cls));

--- a/src/main/java/com/power/doc/template/RpcDocBuildTemplate.java
+++ b/src/main/java/com/power/doc/template/RpcDocBuildTemplate.java
@@ -82,7 +82,7 @@ public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IRpcDo
         for (JavaClass cls : projectBuilder.getJavaProjectBuilder().getClasses()) {
             if (StringUtil.isNotEmpty(apiConfig.getPackageFilters())) {
                 // check package
-                if (!DocUtil.isMatch(apiConfig.getPackageFilters(), cls.getCanonicalName())) {
+                if (!DocUtil.isMatch(apiConfig.getPackageFilters(), cls)) {
                     continue;
                 }
             }
@@ -119,6 +119,10 @@ public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IRpcDo
         String clazName = cls.getCanonicalName();
         List<JavaMethod> methods = cls.getMethods();
         List<RpcJavaMethod> methodDocList = new ArrayList<>(methods.size());
+
+        Set<String> filterMethods = DocUtil.findFilterMethods(clazName);
+        boolean needAllMethods = filterMethods.contains(DocGlobalConstants.DEFAULT_FILTER_METHOD);
+
         for (JavaMethod method : methods) {
             if (method.isPrivate()) {
                 continue;
@@ -129,8 +133,10 @@ public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IRpcDo
             if (StringUtil.isEmpty(method.getComment()) && apiConfig.isStrict()) {
                 throw new RuntimeException("Unable to find comment for method " + method.getName() + " in " + cls.getCanonicalName());
             }
-            RpcJavaMethod apiMethodDoc = convertToRpcJavaMethod(apiConfig, method, null);
-            methodDocList.add(apiMethodDoc);
+            if (needAllMethods || filterMethods.contains(method.getName())) {
+                RpcJavaMethod apiMethodDoc = convertToRpcJavaMethod(apiConfig, method, null);
+                methodDocList.add(apiMethodDoc);
+            }
 
 
         }


### PR DESCRIPTION
Support `packageFilters` to the method level, and it supports regular expressions.

The following configurations have passed tests:

- [x] `"packageFilters": "com.example.controller.PetController"` only outputs the interface of `PetController`
- [x] `"packageFilters": "com.example.controller.*"` outputs all interfaces under the `controller` package
- [x] `"packageFilters": "com.example.controller.*Controller"` outputs all interfaces with the class name ending in `Controller` under the `controller` package
- [x] `"packageFilters": "com.example.controller.Pet.*"` outputs all interfaces with the class name starting with `Pet` under the `controller` package
- [x] `"packageFilters": "com.example.controller.Pet.*Controller"` outputs all interfaces matching the class name `Pet*Controller` under the `controller` package
- [x] `"packageFilters": "com.example.controller.PetController.getPetInfo"` outputs the `getPetInfo` method interface in `PetController`
- [x] `"packageFilters": "com.example.controller.PetController.*"` outputs all interfaces in `PetController`
- [x] `"packageFilters": "com.example.controller.PetController.get.*"` only outputs all interfaces in `PetController` with the method name starting with `get`
- [x] `"packageFilters": "com.example.controller.PetController.*Info"` only outputs all interfaces in `PetController` with the method name ending in `Info`
- [x] `"packageFilters": "com.example.controller.PetController.get.*Info"` only outputs all interfaces in `PetController` that match the method name `get.*Info`