### PR TITLE
fix: https://github.com/smart-doc-group/smart-doc/issues/580

### DIFF
--- a/src/main/java/com/power/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/power/doc/builder/openapi/OpenApiBuilder.java
@@ -132,7 +132,10 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
     public Map<String, Object> buildPathUrlsRequest(ApiConfig apiConfig, ApiMethodDoc apiMethodDoc, ApiDoc apiDoc) {
         Map<String, Object> request = new HashMap<>(20);
         request.put("summary", apiMethodDoc.getDesc());
-        request.put("description", apiMethodDoc.getDetail());
+        if (!Objects.equals(apiMethodDoc.getDesc(), apiMethodDoc.getDetail())) {
+            // When summary and description are equal, there is only one
+            request.put("description", apiMethodDoc.getDetail());
+        }
 //        String tag = StringUtil.isEmpty(apiDoc.getDesc()) ? OPENAPI_TAG : apiDoc.getDesc();
 //        if (StringUtil.isNotEmpty(apiMethodDoc.getGroup())) {
 //            request.put("tags", new String[]{tag});


### PR DESCRIPTION
Path Item Object的summary和description相同时，丢弃description的值