### PR TITLE
fix: https://github.com/smart-doc-group/smart-doc/issues/603

### DIFF
--- a/src/main/java/com/power/doc/utils/DocUtil.java
+++ b/src/main/java/com/power/doc/utils/DocUtil.java
@@ -893,7 +893,7 @@ public class DocUtil {
             return new ArrayList<>(0);
         } else {
             ClassLoader classLoader = config.getClassLoader();
-            Set<ApiErrorCode> errorCodeList = new HashSet<>();
+            Set<ApiErrorCode> errorCodeList = new LinkedHashSet<>();
             try {
                 for (ApiErrorCodeDictionary dictionary : errorCodeDictionaries) {
                     Class<?> clzz = dictionary.getEnumClass();


### PR DESCRIPTION
LinkedHashSet maintains the insertion order of elements.