### PR TITLE
fix:The generated Postman collection does not support file uploads

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -985,7 +985,6 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
                 .collect(Collectors.groupingBy(e -> Objects.equals(e.getType(), DocGlobalConstants.PARAM_TYPE_FILE)));
         List<FormData> fileFormDataList = formDataGroupMap.getOrDefault(Boolean.TRUE, new ArrayList<>());
         if (hasFormDataUploadFile) {
-            formDataList = formDataGroupMap.getOrDefault(Boolean.FALSE, new ArrayList<>());
             apiMethodDoc.setContentType(FILE_CONTENT_TYPE);
         }
 


### PR DESCRIPTION
## Summary(关于这个pr的描述)

fix: The generated Postman collection does not support file uploads #622

### Basic example(pr的用例)

`controller`用例

```java
/**
 * 上传单个文件V1
 * @param userId 用户id
 * @param file 文件
 * @return
 */
@PostMapping(value = "/upload",consumes = "multipart/form-data")
public Result upload(String userId,@RequestParam MultipartFile file) {
    return Result.success();
}

/**
 * 上传单个文件V2
 * @param userId
 * @param userData
 * @param file
 * @return
 */
@PostMapping("upload2")
public Result formData2(String userId,@RequestParam String userData, MultipartFile file){
    return Result.success();
}

/**
 * 批量上传文件
 * @param file 文件
 * @return
 */
@PostMapping(name = "/batchUpload1",consumes = "multipart/form-data")
public Result batchFileUpload1(MultipartFile[] file) {
    return Result.success();
}

/**
 * 批量上传文件1
 * @param file 文件
 * @return
 */
@PostMapping(value = "/batchUpload2",consumes = "multipart/form-data")
public Result batchFileUpload2(List<MultipartFile> file) {
    return Result.success();
}

```

`Postman`效果截图

> Postman version: 10.18.11

使用`PostmanJsonBuilder`生成`postman.json`文件，然后导入到`Postman`工具中，请求参数 `file` 显示为 `File`类型，效果如下:

![piSPXh4.png](https://z1.ax1x.com/2023/10/11/piSPXh4.png)

### Motivation(提出这个pr目的)

fix: issue #622


