### PR TITLE
fix:https://github.com/TongchengOpenSource/smart-doc/issues/623

### DIFF
--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -303,6 +303,7 @@ public class JsonBuildHelper extends BaseHelper {
                         fieldName = StringUtil.isEmpty(customResponseField.getReplaceName()) ? fieldName : customResponseField.getReplaceName();
                     }
                 }
+                fieldName = fieldName.trim();
                 data0.append("\"").append(fieldName).append("\":");
                 String fieldValue = getFieldValueFromMock(subTypeName, tagsMap, typeSimpleName);
                 if (JavaClassValidateUtil.isPrimitive(subTypeName)) {

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -284,6 +284,7 @@ public class ParamsBuildHelper extends BaseHelper {
                         && JavaClassUtil.isTargetChildClass(simpleName, customResponseField.getOwnerClassName()) && isResp) {
                     fieldName = customResponseField.getReplaceName();
                 }
+                fieldName = fieldName.trim();
                 // Analyzing File Type Field
                 if (JavaClassValidateUtil.isFile(fieldGicName)) {
                     ApiParam param = ApiParam.of().setField(pre + fieldName).setType("file")


### PR DESCRIPTION
## Summary(关于这个pr的描述)

fix: #623

### Basic example(pr的用例)

`controller`用例

```java
@PostMapping(value = "/save")
public Result save(User data)  {
    return Result.success();
}

@PostMapping(value = "/saveUserVO", produces = MediaType.APPLICATION_JSON_VALUE)
  public Result saveUserVO(@Valid @RequestBody User vo)  {
      return Result.success();
}
```

实体用例
```java

public class User implements Serializable {
    /**
     * 用户ID
     */
    private String id;

    /**
     * 用户名称
     */
    // @JsonProperty(value = "nickName")
    @JsonProperty(value = " nickName")
    private String name;
  
    /** 省略... */
}
```

`issue`场景复现：

当硬编码为`@JsonProperty(value = " nickName")`，故意有空格时，可复现问题。

此问题是因为底层使用了[qbox](https://github.com/paul-hammant/qdox)解析源码，其获取`Annotation`时，不会处理`value`属性中的值。



## Solution(解决方案)

在获取 `fieldName` 后，使用`trim()`方法去除前后可能存在的空格



## Motivation(提出这个pr目的)

基于逻辑更严谨的考量，提出此`pr`:

- 能够覆盖原 `issue` 中提到的场景 
- 在`qbox`未来可能会处理此类场景前，在`smart-doc`中，先修复**前后空格**的场景。此修复只影响到了生成`json`的场景,包含生成`postman`和`openapi`

fix: issue #623


