### PR TITLE
Fix the issue where the configuration of componentType as NORMAL is not effective.

### DIFF
--- a/src/main/java/com/ly/doc/builder/BaseDocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/BaseDocBuilderTemplate.java
@@ -81,6 +81,7 @@ public class BaseDocBuilderTemplate {
         if (StringUtil.isEmpty(config.getOutPath()) && checkOutPath) {
             throw new RuntimeException("doc output path can't be null or empty");
         }
+        ApiConfig.setInstance(config);
     }
 
     /**

--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -166,7 +166,7 @@ public abstract class AbstractOpenApiBuilder {
         } else if (!isRep && Objects.nonNull(apiMethodDoc.getRequestSchema())) {
             content.put("schema", apiMethodDoc.getRequestSchema());
         } else {
-            content.put("schema", buildBodySchema(apiMethodDoc, ComponentTypeEnum.getComponentEnumByCode(apiConfig.getComponentType()), isRep));
+            content.put("schema", buildBodySchema(apiMethodDoc, isRep));
         }
 
         if (OPENAPI_2_COMPONENT_KRY.equals(componentKey) && !isRep) {
@@ -186,7 +186,7 @@ public abstract class AbstractOpenApiBuilder {
      * @param apiMethodDoc ApiMethodDoc
      * @param isRep        is response
      */
-    public Map<String, Object> buildBodySchema(ApiMethodDoc apiMethodDoc, ComponentTypeEnum componentTypeEnum, boolean isRep) {
+    public Map<String, Object> buildBodySchema(ApiMethodDoc apiMethodDoc, boolean isRep) {
         Map<String, Object> schema = new HashMap<>(10);
         Map<String, Object> innerScheme = new HashMap<>(10);
         // For response
@@ -204,7 +204,7 @@ public abstract class AbstractOpenApiBuilder {
 
         // for request
         String requestRef;
-        String randomName = ComponentTypeEnum.getRandomName(componentTypeEnum, apiMethodDoc);
+        String randomName = ComponentTypeEnum.getRandomName(ApiConfig.getInstance().getComponentType(), apiMethodDoc);
         if (apiMethodDoc.getContentType().equals(DocGlobalConstants.URL_CONTENT_TYPE)) {
             requestRef = componentKey + OpenApiSchemaUtil.getClassNameFromParams(apiMethodDoc.getQueryParams());
         } else {
@@ -332,7 +332,7 @@ public abstract class AbstractOpenApiBuilder {
      *
      * @param apiDocs List of ApiDoc
      */
-    abstract public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs, ComponentTypeEnum componentTypeEnum);
+    abstract public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs);
 
     /**
      * component schema properties

--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -22,7 +22,6 @@
  */
 package com.ly.doc.builder.openapi;
 
-import com.ly.doc.constants.ComponentTypeEnum;
 import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.Methods;
 import com.ly.doc.model.*;
@@ -87,7 +86,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
         Set<OpenApiTag> tags = new HashSet<>();
         json.put("tags", tags);
         json.put("paths", buildPaths(config, apiDocList, tags));
-        json.put("components", buildComponentsSchema(apiDocList, ComponentTypeEnum.getComponentEnumByCode(config.getComponentType())));
+        json.put("components", buildComponentsSchema(apiDocList));
 
         String filePath = config.getOutPath();
         filePath = filePath + DocGlobalConstants.OPEN_API_JSON;
@@ -264,7 +263,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
     }
 
     @Override
-    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs, ComponentTypeEnum componentTypeEnum) {
+    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs) {
         Map<String, Object> schemas = new HashMap<>(4);
         Map<String, Object> component = new HashMap<>();
         component.put(DocGlobalConstants.DEFAULT_PRIMITIVE, STRING_COMPONENT);

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -21,7 +21,6 @@
  */
 package com.ly.doc.builder.openapi;
 
-import com.ly.doc.constants.ComponentTypeEnum;
 import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.model.*;
 import com.ly.doc.utils.DocUtil;
@@ -88,7 +87,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         Set<OpenApiTag> tags = new HashSet<>();
         json.put("tags", tags);
         json.put("paths", buildPaths(config, apiDocList, tags));
-        json.put("definitions", buildComponentsSchema(apiDocList, ComponentTypeEnum.getComponentEnumByCode(config.getComponentType())));
+        json.put("definitions", buildComponentsSchema(apiDocList));
 
         String filePath = config.getOutPath();
         filePath = filePath + DocGlobalConstants.OPEN_API_JSON;
@@ -275,7 +274,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
     }
 
     @Override
-    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs, ComponentTypeEnum componentTypeEnum) {
+    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs) {
         Map<String, Object> component = new HashMap<>();
         component.put(DocGlobalConstants.DEFAULT_PRIMITIVE, STRING_COMPONENT);
         apiDocs.forEach(

--- a/src/main/java/com/ly/doc/constants/ComponentTypeEnum.java
+++ b/src/main/java/com/ly/doc/constants/ComponentTypeEnum.java
@@ -57,13 +57,4 @@ public enum ComponentTypeEnum {
     public String getComponentType() {
         return componentType;
     }
-
-    public static ComponentTypeEnum getComponentEnumByCode(String code) {
-        for (ComponentTypeEnum typeEnum : ComponentTypeEnum.values()) {
-            if (typeEnum.getComponentType().equals(code)) {
-                return typeEnum;
-            }
-        }
-        return RANDOM;
-    }
 }

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -39,14 +39,7 @@ import com.ly.doc.handler.ICustomJavaMethodHandler;
  */
 public class ApiConfig {
 
-    private final static ApiConfig apiConfig = new ApiConfig();
-
-    private ApiConfig() {
-    }
-
-    public static ApiConfig getInstance() {
-        return apiConfig;
-    }
+    private static ApiConfig instance;
 
     /**
      * Web server base url
@@ -376,7 +369,7 @@ public class ApiConfig {
      * build random component for openApi
      * @see ComponentTypeEnum
      */
-    private String componentType;
+    private ComponentTypeEnum componentType = ComponentTypeEnum.RANDOM;
 
     /**
      * whether to build the doc incrementally
@@ -388,13 +381,12 @@ public class ApiConfig {
      */
     private String baseDir;
 
-    public String getComponentType() {
-        return componentType;
+    public static ApiConfig getInstance() {
+        return instance;
     }
 
-    public ApiConfig setComponentType(String componentType) {
-        this.componentType = componentType;
-        return this;
+    public static void setInstance(ApiConfig instance) {
+        ApiConfig.instance = instance;
     }
 
     public String getCodePath() {
@@ -1004,6 +996,15 @@ public class ApiConfig {
 
     public void setJarSourcePaths(SourceCodePath... jarSourcePaths) {
         this.jarSourcePaths = CollectionUtil.asList(jarSourcePaths);
+    }
+
+    public ComponentTypeEnum getComponentType() {
+        return componentType;
+    }
+
+    public ApiConfig setComponentType(ComponentTypeEnum componentType) {
+        this.componentType = componentType;
+        return this;
     }
 
     public boolean isIncrement() {

--- a/src/main/java/com/ly/doc/utils/OpenApiSchemaUtil.java
+++ b/src/main/java/com/ly/doc/utils/OpenApiSchemaUtil.java
@@ -88,7 +88,7 @@ public class OpenApiSchemaUtil {
     }
 
     public static String getClassNameFromParams(List<ApiParam> apiParams) {
-        ComponentTypeEnum componentTypeEnum = ComponentTypeEnum.getComponentEnumByCode(ApiConfig.getInstance().getComponentType());
+        ComponentTypeEnum componentTypeEnum = ApiConfig.getInstance().getComponentType();
         // if array[Primitive] or Primitive
         if (CollectionUtil.isNotEmpty(apiParams) && apiParams.size() == 1
                 && StringUtil.isEmpty(apiParams.get(0).getClassName())

--- a/src/test/java/com/ly/doc/ApiDocTest.java
+++ b/src/test/java/com/ly/doc/ApiDocTest.java
@@ -22,7 +22,7 @@ public class ApiDocTest {
     @Test
     public void testBuilderControllersApi() {
         @Deprecated
-        ApiConfig config = ApiConfig.getInstance();
+        ApiConfig config = new ApiConfig();
         config.setServerUrl("http://127.0.0.1:8899");
         // config.setStrict(true);
         config.setOpenUrl("http://localhost:7700/api");

--- a/src/test/java/com/ly/doc/qbox/QboxScanSourceTest.java
+++ b/src/test/java/com/ly/doc/qbox/QboxScanSourceTest.java
@@ -25,7 +25,7 @@ public class QboxScanSourceTest {
         String outPath = Paths.get("target").toAbsolutePath().toString();
 
         // config and scan
-        ApiConfig config = ApiConfig.getInstance();
+        ApiConfig config = new ApiConfig();
         config.setServerUrl("HSF://127.0.0.1:8088");
         config.setOpenUrl("http://demo.torna.cn/api");
         config.setDebugEnvName("测试环境");


### PR DESCRIPTION
The previous PR #661 had issues when merging commits, so it's being resubmitted.

When using the object obtained from ApiConfig.getInstance(), all its fields are unassigned, resulting in getComponentType() returning null and defaulting to the RANDOM mode. An ApiConfig.setInstance() method has been added to initialize ApiConfig.instance.

之前的  PR #661  在合并 commit 的时候有问题，所以重提一个。

使用 ApiConfig.getInstance() 获取的对象，里面的字段都是未赋值的，导致 getComponentType() 为 null，默认走 RANDOM 模式。
增加 ApiConfig.setInstance() 方法，为 ApiConfig.instance 进行初始化。