### PR TITLE
Support the generation of JMeter performance testing scripts

### DIFF
--- a/src/main/java/com/ly/doc/builder/DocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/DocBuilderTemplate.java
@@ -133,6 +133,7 @@ public class DocBuilderTemplate extends BaseDocBuilderTemplate {
         tpl.binding(TemplateVariable.API_DOC_LIST.getVariable(), apiDocList);
         tpl.binding(TemplateVariable.ERROR_CODE_LIST.getVariable(), errorCodeList);
         tpl.binding(TemplateVariable.VERSION_LIST.getVariable(), config.getRevisionLogs());
+        tpl.binding(TemplateVariable.LANGUAGE.getVariable(), config.getLanguage());
         tpl.binding(TemplateVariable.VERSION.getVariable(), now);
         tpl.binding(TemplateVariable.INDEX_ALIAS.getVariable(), index);
         tpl.binding(TemplateVariable.CREATE_TIME.getVariable(), strTime);

--- a/src/main/java/com/ly/doc/builder/JMeterBuilder.java
+++ b/src/main/java/com/ly/doc/builder/JMeterBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018-2023 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ly.doc.builder;
+
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.factory.BuildTemplateFactory;
+import com.ly.doc.helper.JavaProjectBuilderHelper;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.template.IDocBuildTemplate;
+import com.power.common.util.DateTimeUtil;
+import com.thoughtworks.qdox.JavaProjectBuilder;
+
+import java.util.List;
+
+/**
+ * used to generate jmx file for Jmeter
+ * @author Lansg
+ */
+public class JMeterBuilder {
+
+    private static final String API_EXTENSION = ".jmx";
+
+    private static final String DATE_FORMAT = "yyyyMMddHHmm";
+
+    /**
+     * @param config ApiConfig
+     */
+    public static void buildApiDoc(ApiConfig config) {
+        JavaProjectBuilder javaProjectBuilder = JavaProjectBuilderHelper.create();
+        buildApiDoc(config, javaProjectBuilder);
+    }
+
+    /**
+     * Only for smart-doc maven plugin and gradle plugin.
+     *
+     * @param config             ApiConfig
+     * @param javaProjectBuilder ProjectDocConfigBuilder
+     */
+    public static void buildApiDoc(ApiConfig config, JavaProjectBuilder javaProjectBuilder) {
+        DocBuilderTemplate builderTemplate = new DocBuilderTemplate();
+        builderTemplate.checkAndInit(config, Boolean.TRUE);
+        config.setAdoc(false);
+        config.setParamsDataToTree(false);
+        ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder);
+        String version = config.isCoverOld() ? "" : "-V" + DateTimeUtil.long2Str(System.currentTimeMillis(), DATE_FORMAT);
+        String docName = builderTemplate.allInOneDocName(config, "JmeterApiDoc" + version + ".jmx", ".jmx");
+//        apiDocList = docBuildTemplate.handleApiGroup(apiDocList, config);
+        builderTemplate.buildAllInOne(apiDocList, config, javaProjectBuilder, DocGlobalConstants.JMETER_TPL, docName);
+    }
+}

--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -39,6 +39,7 @@ import com.ly.doc.utils.OpenApiSchemaUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.ly.doc.constants.DocGlobalConstants.*;
 
@@ -116,7 +117,11 @@ public abstract class AbstractOpenApiBuilder {
         }
         for (Map.Entry<String, TagDoc> docEntry : DocMapping.TAG_DOC.entrySet()) {
             String tag = docEntry.getKey();
-            tags.add(OpenApiTag.of(tag, tag));
+            tags.addAll(docEntry.getValue().getClazzDocs()
+                    .stream()
+                    //optimize tag content for compatible to swagger
+                    .map(doc -> OpenApiTag.of(doc.getName(), doc.getDesc()))
+                    .collect(Collectors.toSet()));
         }
         return pathMap;
     }

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -137,12 +137,8 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         Map<String, Object> request = new HashMap<>(20);
         request.put("summary", apiMethodDoc.getDesc());
         request.put("description", apiMethodDoc.getDetail());
-        String tag = StringUtil.isEmpty(apiDoc.getDesc()) ? DocGlobalConstants.OPENAPI_TAG : apiDoc.getDesc();
-        if (StringUtil.isNotEmpty(apiMethodDoc.getGroup())) {
-            request.put("tags", new String[]{tag});
-        } else {
-            request.put("tags", new String[]{tag});
-        }
+        request.put("tags", Arrays.asList(apiDoc.getName(),apiDoc.getDesc(), apiMethodDoc.getGroup())
+                .stream().filter(StringUtil::isNotEmpty).toArray(n->new String[n]));
         List<Map<String, Object>> parameters = buildParameters(apiMethodDoc);
         //requestBody
         if (CollectionUtil.isNotEmpty(apiMethodDoc.getRequestParams())) {
@@ -160,7 +156,8 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         request.put("responses", buildResponses(apiConfig, apiMethodDoc));
         request.put("deprecated", apiMethodDoc.isDeprecated());
         String operationId = apiMethodDoc.getUrl().replace(apiMethodDoc.getServerUrl(), "");
-        request.put("operationId", String.join("", OpenApiSchemaUtil.getPatternResult("[A-Za-z0-9{}]*", operationId)));
+        //make sure operationId is unique and can be used as a method name
+        request.put("operationId",apiMethodDoc.getName()+"_"+apiMethodDoc.getMethodId()+"UsingOn"+apiMethodDoc.getType());
 
         return request;
     }

--- a/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
+++ b/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
@@ -42,6 +42,8 @@ public interface DocGlobalConstants {
     String RANDOM_MOCK = "randomMock";
     String API_DOC_MD_TPL = "ApiDoc.md";
 
+    String JMETER_TPL = "JMeter.jmx";
+
     String API_DOC_ADOC_TPL = "ApiDoc.adoc";
 
     String ALL_IN_ONE_MD_TPL = "AllInOne.md";

--- a/src/main/java/com/ly/doc/constants/TemplateVariable.java
+++ b/src/main/java/com/ly/doc/constants/TemplateVariable.java
@@ -41,6 +41,7 @@ public enum TemplateVariable {
     ERROR_LIST_TITLE("errorListTitle"),
     CREATE_TIME("createTime"),
     PROJECT_NAME("projectName"),
+    LANGUAGE("language"),
     DICT_LIST("dictList"),
     DICT_LIST_TITLE("dictListTitle"),
     DICT_ORDER("dictListOrder"),

--- a/src/main/resources/template/JMeter.jmx
+++ b/src/main/resources/template/JMeter.jmx
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="${projectName}" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+	  <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="<% if(language.code == 'zh-CN') { %>用户定义的变量<% } else { %>Arguments<% } %>" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+        <%
+        for(api in apiDocList){
+        %>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="${api.desc}" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="<% if(language.code == 'zh-CN') { %>循环控制器<% } else { %>LoopController<% } %>" enabled="true">
+		  <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <%
+        for(doc in api.list){
+        %>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="${doc.desc}" enabled="true">
+          <%if(isNotEmpty(doc.requestExample.jsonBody)){%>
+		  <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">
+${doc.requestExample.jsonBody}
+                </stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+		  <%} else if(isNotEmpty(doc.queryParams)) {%>
+			  
+		  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+		  <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+			<collectionProp name="Arguments.arguments">
+			  <%
+			  for(param in doc.queryParams){
+		      %>
+				<elementProp name="" elementType="HTTPArgument">
+					<boolProp name="HTTPArgument.always_encode">false</boolProp>
+					<stringProp name="Argument.name">${param.field}</stringProp>
+					<stringProp name="Argument.metadata">=</stringProp>
+				</elementProp>
+			 <%}%>
+			</collectionProp>
+		</elementProp>
+			
+		  <% } else if(isNotEmpty(doc.pathParams)) {%>
+			  
+		  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+		  <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+			<collectionProp name="Arguments.arguments">
+			  <%
+			  for(param in doc.pathParams){
+			  %>
+				<elementProp name="" elementType="HTTPArgument">
+					<boolProp name="HTTPArgument.always_encode">false</boolProp>
+					<stringProp name="Argument.name">${param.field}</stringProp>
+					<stringProp name="Argument.metadata">=</stringProp>
+				</elementProp>
+			  <%}%>
+			</collectionProp>
+		  </elementProp>
+
+		  <%}%>
+          <stringProp name="HTTPSampler.domain">${doc.serverUrl}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding">utf-8</stringProp>
+          <stringProp name="HTTPSampler.path">${doc.url}</stringProp>
+          <stringProp name="HTTPSampler.method">${doc.type}</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="<% if(language.code == 'zh-CN') { %>HTTP信息头管理器<% } else { %>HeaderManager<% } %>" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">${doc.contentType}</stringProp>
+              </elementProp>
+              <%if(isNotEmpty(doc.requestHeaders)){%>
+                <%
+                for(param in doc.requestHeaders){
+                %>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">${param.name}</stringProp>
+                <stringProp name="Header.value">${param.value}</stringProp>
+              </elementProp>
+                <%}%>
+            <%}%>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="<% if(language.code == 'zh-CN') { %>察看结果树<% } else { %>ResultCollector<% } %>" enabled="true">
+            <boolProp name="ResultCollector.error_logging">false</boolProp>
+            <objProp>
+              <name>saveConfig</name>
+              <value class="SampleSaveConfiguration">
+                <time>true</time>
+                <latency>true</latency>
+                <timestamp>true</timestamp>
+                <success>true</success>
+                <label>true</label>
+                <code>true</code>
+                <message>true</message>
+                <threadName>true</threadName>
+                <dataType>true</dataType>
+                <encoding>false</encoding>
+                <assertions>true</assertions>
+                <subresults>true</subresults>
+                <responseData>false</responseData>
+                <samplerData>false</samplerData>
+                <xml>false</xml>
+                <fieldNames>true</fieldNames>
+                <responseHeaders>false</responseHeaders>
+                <requestHeaders>false</requestHeaders>
+                <responseDataOnError>false</responseDataOnError>
+                <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+                <assertionsResultsToSave>0</assertionsResultsToSave>
+                <bytes>true</bytes>
+                <sentBytes>true</sentBytes>
+                <url>true</url>
+                <threadCounts>true</threadCounts>
+                <idleTime>true</idleTime>
+                <connectTime>true</connectTime>
+              </value>
+            </objProp>
+            <stringProp name="filename"></stringProp>
+          </ResultCollector>
+          <hashTree/>
+        </hashTree>
+            <% } %>
+      </hashTree>
+      <%}%>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/src/test/java/com/ly/doc/ApiDocTest.java
+++ b/src/test/java/com/ly/doc/ApiDocTest.java
@@ -1,5 +1,8 @@
 package com.ly.doc;
 
+import com.ly.doc.builder.ApiDocBuilder;
+import com.ly.doc.builder.JMeterBuilder;
+import com.ly.doc.constants.DocLanguage;
 import com.ly.doc.model.ApiConfig;
 import com.ly.doc.model.SourceCodePath;
 import com.power.common.util.DateTimeUtil;
@@ -17,12 +20,14 @@ public class ApiDocTest {
 
     /**
      * 包括设置请求头，缺失注释的字段批量在文档生成期使用定义好的注释
+     * test html
      */
     @Deprecated
     @Test
     public void testBuilderControllersApi() {
         @Deprecated
         ApiConfig config = new ApiConfig();
+        
         config.setServerUrl("http://127.0.0.1:8899");
         // config.setStrict(true);
         config.setOpenUrl("http://localhost:7700/api");
@@ -32,29 +37,113 @@ public class ApiDocTest {
         config.setDebugEnvName("测试环境");
         config.setInlineEnum(true);
         config.setStyle("randomLight");
-        config.setCreateDebugPage(true);
+        config.setCreateDebugPage(false);
         // config.setAuthor("test");
-        config.setDebugEnvUrl("http://127.0.0.1");
+//        config.setDebugEnvUrl("http://127.0.0.1");
         // config.setTornaDebug(true);
         config.setAllInOne(false);
         config.setCoverOld(true);
-        config.setOutPath("D://md3");
+        config.setOutPath("D:\\smart-doc\\docs\\html");
         // config.setMd5EncryptedHtmlName(true);
         config.setFramework(FrameworkEnum.SPRING.getFramework());
         // 不指定SourcePaths默认加载代码为项目src/main/java下的
         config.setSourceCodePaths(
                 SourceCodePath.builder().setDesc("本项目代码")
-                        .setPath("C:\\Users\\xingzi\\Desktop\\example")
+                        .setPath("D:\\smart-doc\\test-project")
         );
-        config.setPackageFilters("com.example.demo.controller.*");
+        config.setPackageFilters("com.power.doc.controller.*");
+        config.setBaseDir("D:\\smart-doc\\test-project\\smart-doc-example-cn-master");
+        config.setCodePath("/src/main/java");
 
 
-        config.setJarSourcePaths(SourceCodePath.builder()
-                .setPath("D:\\xxxx-sources.jar")
-        );
+//        config.setJarSourcePaths(SourceCodePath.builder()
+//                .setPath("D:\\xxxx-sources.jar")
+//        );
         long start = System.currentTimeMillis();
+
+
         HtmlApiDocBuilder.buildApiDoc(config);
-        // HtmlApiDocBuilder.buildApiDoc(config);
+//        ApiDocBuilder.buildApiDoc(config);
+//        JmxDocBuilder.buildApiDoc(config);
+
+        long end = System.currentTimeMillis();
+        DateTimeUtil.printRunTime(end, start);
+    }
+
+    /**
+     * test jmeter
+     */
+    @Deprecated
+    @Test
+    public void testJmxBuilderControllersApi() {
+        @Deprecated
+        ApiConfig config = new ApiConfig();
+//        ApiConfig config = ApiConfig.getInstance();
+        config.setServerUrl("http://127.0.0.1:8899");
+        config.setOpenUrl("http://localhost:7700/api");
+        config.setAppToken("be4211613a734b45888c075741680e49");
+
+        config.setDebugEnvName("测试环境");
+        config.setLanguage(DocLanguage.CHINESE);
+//        config.setLanguage(DocLanguage.ENGLISH);
+        config.setInlineEnum(true);
+        config.setStyle("randomLight");
+        config.setCreateDebugPage(false);
+        config.setAllInOne(true);
+        config.setCoverOld(false);
+        config.setOutPath("D:\\smart-doc\\docs\\jmx1");
+        config.setFramework(FrameworkEnum.SPRING.getFramework());
+        // 不指定SourcePaths默认加载代码为项目src/main/java下的
+        config.setSourceCodePaths(
+                SourceCodePath.builder().setDesc("本项目代码")
+                        .setPath("D:\\smart-doc\\test-project")
+        );
+        config.setPackageFilters("com.power.doc.controller.*");
+        config.setBaseDir("D:\\smart-doc\\test-project\\smart-doc-example-cn-master");
+        config.setCodePath("/src/main/java");
+
+        long start = System.currentTimeMillis();
+
+        JMeterBuilder.buildApiDoc(config);
+
+        long end = System.currentTimeMillis();
+        DateTimeUtil.printRunTime(end, start);
+    }
+
+    /**
+     * test markdown
+     */
+    @Deprecated
+    @Test
+    public void testMdBuilderControllersApi1() {
+        @Deprecated
+        ApiConfig config = new ApiConfig();
+//        ApiConfig config = ApiConfig.getInstance();
+        config.setServerUrl("http://127.0.0.1:8899");
+        config.setOpenUrl("http://localhost:7700/api");
+        config.setAppToken("be4211613a734b45888c075741680e49");
+
+        config.setDebugEnvName("测试环境");
+        config.setInlineEnum(true);
+        config.setStyle("randomLight");
+        config.setCreateDebugPage(false);
+        config.setAllInOne(true);
+        config.setCoverOld(false);
+        config.setOutPath("D:\\smart-doc\\docs\\jmx1");
+        config.setFramework(FrameworkEnum.SPRING.getFramework());
+        // 不指定SourcePaths默认加载代码为项目src/main/java下的
+        config.setSourceCodePaths(
+                SourceCodePath.builder().setDesc("本项目代码")
+                        .setPath("D:\\smart-doc\\test-project")
+        );
+        config.setPackageFilters("com.power.doc.controller.*");
+        config.setBaseDir("D:\\smart-doc\\test-project\\smart-doc-example-cn-master");
+        config.setCodePath("/src/main/java");
+
+        long start = System.currentTimeMillis();
+
+        ApiDocBuilder.buildApiDoc(config);
+
         long end = System.currentTimeMillis();
         DateTimeUtil.printRunTime(end, start);
     }


### PR DESCRIPTION
### What does this PR do? 
Generate .jmx files for jmeter,import the file in jmeter to use.
Support the generation of JMeter performance testing scripts:https://github.com/TongchengOpenSource/smart-doc/issues/653

### Checklist: 清单：
● Supports Thread Groups and Samplers for each specific interface
![image1](https://github.com/TongchengOpenSource/smart-doc/assets/59016860/efc6f181-2819-4c69-9445-9e56417da8a6)

● Parameters that support get requests are presented in "Parameters"
![image2](https://github.com/TongchengOpenSource/smart-doc/assets/59016860/af0a7cb3-5b21-40e8-99ab-9864a88dbfc9)

● Supports form-data type parameters, which are presented in "Parameters"
![image3](https://github.com/TongchengOpenSource/smart-doc/assets/59016860/25fa6c3f-28a5-4e99-a6bc-27432071f885)
![image4](https://github.com/TongchengOpenSource/smart-doc/assets/59016860/7df547ca-6725-4f14-841b-659a01c5ef4c)


● Supports data in json format, presented in "Body Data"
![image5](https://github.com/TongchengOpenSource/smart-doc/assets/59016860/6eb65da8-e5a5-439b-ba9d-d77014a2f6e5)

