### PR TITLE
兼容原生Swagger的Tag内容格式

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -119,7 +119,7 @@ public abstract class AbstractOpenApiBuilder {
             String tag = docEntry.getKey();
             tags.addAll(docEntry.getValue().getClazzDocs()
                     .stream()
-                    //优化tag形式,兼容swagger
+                    //optimize tag content for copatible to swagger
                     .map(doc -> OpenApiTag.of(doc.getName(), doc.getDesc()))
                     .collect(Collectors.toSet()));
         }

--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -117,9 +117,10 @@ public abstract class AbstractOpenApiBuilder {
         }
         for (Map.Entry<String, TagDoc> docEntry : DocMapping.TAG_DOC.entrySet()) {
             String tag = docEntry.getKey();
-            //添加controller作为tag
-            tags.addAll(docEntry.getValue().getClazzDocs().stream().map(ApiDoc::getName)
-                    .map(name -> OpenApiTag.of(name, name))
+            tags.addAll(docEntry.getValue().getClazzDocs()
+                    .stream()
+                    //优化tag形式,兼容swagger
+                    .map(doc -> OpenApiTag.of(doc.getName(), doc.getDesc()))
                     .collect(Collectors.toSet()));
         }
         return pathMap;

--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -39,6 +39,7 @@ import com.ly.doc.utils.OpenApiSchemaUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.ly.doc.constants.DocGlobalConstants.*;
 
@@ -116,7 +117,10 @@ public abstract class AbstractOpenApiBuilder {
         }
         for (Map.Entry<String, TagDoc> docEntry : DocMapping.TAG_DOC.entrySet()) {
             String tag = docEntry.getKey();
-            tags.add(OpenApiTag.of(tag, tag));
+            //添加controller作为tag
+            tags.addAll(docEntry.getValue().getClazzDocs().stream().map(ApiDoc::getName)
+                    .map(name -> OpenApiTag.of(name, name))
+                    .collect(Collectors.toSet()));
         }
         return pathMap;
     }

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -156,6 +156,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         request.put("responses", buildResponses(apiConfig, apiMethodDoc));
         request.put("deprecated", apiMethodDoc.isDeprecated());
         String operationId = apiMethodDoc.getUrl().replace(apiMethodDoc.getServerUrl(), "");
+        //make sure operationId is unique and can be used as a method name
         request.put("operationId",apiMethodDoc.getName()+"_"+apiMethodDoc.getMethodId()+"UsingOn"+apiMethodDoc.getType());
 
         return request;

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -137,12 +137,8 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         Map<String, Object> request = new HashMap<>(20);
         request.put("summary", apiMethodDoc.getDesc());
         request.put("description", apiMethodDoc.getDetail());
-        String tag = StringUtil.isEmpty(apiDoc.getDesc()) ? DocGlobalConstants.OPENAPI_TAG : apiDoc.getDesc();
-        if (StringUtil.isNotEmpty(apiMethodDoc.getGroup())) {
-            request.put("tags", new String[]{tag});
-        } else {
-            request.put("tags", new String[]{tag});
-        }
+        request.put("tags", Arrays.asList(apiDoc.getName(),apiDoc.getDesc(), apiMethodDoc.getGroup())
+                .stream().filter(StringUtil::isNotEmpty).toArray(n->new String[n]));
         List<Map<String, Object>> parameters = buildParameters(apiMethodDoc);
         //requestBody
         if (CollectionUtil.isNotEmpty(apiMethodDoc.getRequestParams())) {
@@ -160,7 +156,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         request.put("responses", buildResponses(apiConfig, apiMethodDoc));
         request.put("deprecated", apiMethodDoc.isDeprecated());
         String operationId = apiMethodDoc.getUrl().replace(apiMethodDoc.getServerUrl(), "");
-        request.put("operationId", String.join("", OpenApiSchemaUtil.getPatternResult("[A-Za-z0-9{}]*", operationId)));
+        request.put("operationId",apiMethodDoc.getName()+"_"+apiMethodDoc.getMethodId()+"UsingOn"+apiMethodDoc.getType());
 
         return request;
     }


### PR DESCRIPTION
原生Swagger的Tag信息包含controller类和方法等信息，前端框架可以根据tag内容和operationId自动生成前端代码。目前smart-doc生成的swagger协议中，Tag内容只包括接口描述，无法被前端框架使用。
变更点包含三部分:
doc的tag内容：name=类名，description=类描述（原实现：name和description都为接口描述）
path的tag内容：[类名,类描述] （原实现：类描述）
operationId：{方法名}_{方法ID}Using{Type}，保持唯一，可用于前端自动生成方法名称。（原实现：url格式化处理）