### PR TITLE
fix: error reporting information

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -955,7 +955,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
                 if (!JavaClassValidateUtil.isPrimitive(gicName)
                         && !configBuilder.getJavaProjectBuilder().getClassByName(gicName).isEnum()) {
                     throw new RuntimeException("can't support binding Collection on method "
-                            + method.getName() + "Check it in " + method.getDeclaringClass().getCanonicalName());
+                            + method.getName() + " Check it in " + method.getDeclaringClass().getCanonicalName());
                 }
                 String value;
                 JavaClass javaClass1 = configBuilder.getClassByName(gicName);


### PR DESCRIPTION
原先报错长这样：
![image](https://github.com/TongchengOpenSource/smart-doc/assets/1698794/9f71206b-c978-40d5-9e77-99a26b5fd04e)

会让人误解为方式是`saveAutoBindGroupTasksCheck`, 单其实是`saveAutoBindGroupTasks`