### PR TITLE
fix: Incorrect documentation example type when the return type is "void"

### DIFF
--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -146,7 +146,7 @@ public class DocUtil {
         }
         if (javaPrimaryType(type)) {
             return value;
-        } else if ("Void".equals(type)) {
+        } else if ("Void".equalsIgnoreCase(type)) {
             return "null";
         } else {
             return "\"" + value + "\"";


### PR DESCRIPTION
fix #725 