### PR TITLE
feat #749: add new tag @extension to support openapi extensions.

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -149,7 +149,10 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
         paths.add(apiMethodDoc.getType());
         String operationId = paths.stream().filter(StringUtils::isNotEmpty).collect(Collectors.joining("-"));
         request.put("operationId", operationId);
-
+        //add extension attribution
+        if ( apiMethodDoc.getExtensions() != null ){
+            apiMethodDoc.getExtensions().entrySet().forEach( e-> request.put("x-"+e.getKey(), e.getValue()));
+        }
         return request;
     }
 

--- a/src/main/java/com/ly/doc/constants/DocTags.java
+++ b/src/main/java/com/ly/doc/constants/DocTags.java
@@ -137,4 +137,8 @@ public interface DocTags {
      * dubbo service name
      */
     String SERVICE = "service";
+    /**
+     * extension for openapi
+     */
+    String EXTENSION = "extension";
 }

--- a/src/main/java/com/ly/doc/model/ApiMethodDoc.java
+++ b/src/main/java/com/ly/doc/model/ApiMethodDoc.java
@@ -209,6 +209,11 @@ public class ApiMethodDoc implements IMethod, Serializable, Cloneable {
      */
     private String version;
 
+    /**
+     * extension attribution
+     */
+    private Map<String, Object> extensions;
+
     public String getVersion() {
         return version;
     }
@@ -494,6 +499,14 @@ public class ApiMethodDoc implements IMethod, Serializable, Cloneable {
         this.clazzDoc = clazzDoc;
     }
 
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("{");
@@ -539,6 +552,8 @@ public class ApiMethodDoc implements IMethod, Serializable, Cloneable {
             .append(responseParams);
         sb.append(",\"deprecated\":")
             .append(deprecated);
+        sb.append(",\"extensions\":")
+                .append(extensions);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -496,13 +496,10 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
             apiMethodDoc.setResponseParams(responseParams);
 
             //handle extension
-            List<DocletTag> extensions = method.getTagsByName(DocTags.EXTENSION);
+            Map<String, String> extensions = DocUtil.getCommentsByTag(method, DocTags.EXTENSION, null);
             if (extensions != null){
                 Map extensionParams = apiMethodDoc.getExtensions() != null ? apiMethodDoc.getExtensions() : new HashMap();
-                extensions.forEach(e -> {
-                    Map<String, Object> map = JsonUtil.toObject(e.getValue(), Map.class);
-                    map.entrySet().stream().forEach( item -> extensionParams.put(item.getKey(), item.getValue()));
-                });
+                extensions.entrySet().stream().forEach( e -> extensionParams.put(e.getKey(), DocUtil.detectTagValue(e.getValue())));
                 apiMethodDoc.setExtensions( extensionParams );
             }
 

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -495,6 +495,17 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
             apiMethodDoc.setRequestSchema(docJavaMethod.getRequestSchema());
             apiMethodDoc.setResponseParams(responseParams);
 
+            //handle extension
+            List<DocletTag> extensions = method.getTagsByName(DocTags.EXTENSION);
+            if (extensions != null){
+                Map extensionParams = apiMethodDoc.getExtensions() != null ? apiMethodDoc.getExtensions() : new HashMap();
+                extensions.forEach(e -> {
+                    Map<String, Object> map = JsonUtil.toObject(e.getValue(), Map.class);
+                    map.entrySet().stream().forEach( item -> extensionParams.put(item.getKey(), item.getValue()));
+                });
+                apiMethodDoc.setExtensions( extensionParams );
+            }
+
             TornaUtil.setTornaArrayTags(docJavaMethod.getJavaMethod(), apiMethodDoc, apiConfig);
             methodDocList.add(apiMethodDoc);
         }

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -575,7 +575,7 @@ public class DocUtil {
             if (StringUtil.isEmpty(value) && StringUtil.isNotEmpty(className)) {
                 throw new RuntimeException(tagValNullMsg);
             }
-            if (DocTags.PARAM.equals(tagName)) {
+            if (DocTags.PARAM.equals(tagName) || DocTags.EXTENSION.equals(tagName)) {
                 String pName = value;
                 String pValue = DocGlobalConstants.NO_COMMENTS_FOUND;
                 int idx = value.indexOf(" ");
@@ -1234,5 +1234,22 @@ public class DocUtil {
             }
         }
         return path;
+    }
+
+    /**
+     * parse tag value, detect the value type, should be one type of String, Map, List
+     * @param value tag value
+     * @return one of String, Map, List
+     */
+    public static Object detectTagValue(String value){
+        String v = value.trim();
+        //if the value is a List
+        if (v.startsWith("[") && v.endsWith("]")){
+            return JsonUtil.toObject(v, List.class);
+        }
+        if (v.startsWith("{") && v.endsWith("}")){
+            return JsonUtil.toObject(v, Map.class);
+        }
+        return v;
     }
 }


### PR DESCRIPTION
add new tag @extension to support openapi extensions.

Add @extension tag on a method like this:
there is a json string after @extension tag
```
/**
 * 删除网卡
 * @extension {"group":"group1"}
 * @param interfaceRemoveArg xxx
 * @apiNote xxx
 * @return
 */
@PostMapping("/interface-remove")
@ResponseBody
public HttpResponse<IdResult> remove(@Validated @RequestBody InterfaceRemoveArg interfaceRemoveArg , BindingResult br) {
...
}
```
and output the content in openapi.json:
```
{
  "paths":{
    "/xxx/interface-remove": {
      "post": {
        "summary": "删除网卡",
        "deprecated": false,
        "tags": [
          "云服务器"
        ],
        "requestBody": {
          ...
        },
        "responses": {
        ...
        },
        "operationId": "xxx-POST",
        "x-group": "group1",
        "parameters": [
             ...
        ]
      }
    }
  }
}
```
It will add  **"x-*"** attributions for the @extension tag, eg: **x-group**
you can add more than one extension in your need
