### PR TITLE
fixed #758 fixed #749: add extension in parameters to support openapi…

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -466,6 +466,9 @@ public abstract class AbstractOpenApiBuilder {
                 propertiesData.put("description", apiParam.getDesc() + "(object)");
             }
         }
+        if (apiParam.getExtensions() != null && !apiParam.getExtensions().isEmpty()){
+            apiParam.getExtensions().entrySet().forEach( e-> propertiesData.put("x-"+e.getKey(), e.getValue()));
+        }
 
         return propertiesData;
     }

--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -31,6 +31,7 @@ import com.power.common.util.FileUtil;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
 import com.ly.doc.model.openapi.OpenApiTag;
 import com.ly.doc.utils.JsonUtil;
+import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import org.apache.commons.lang3.StringUtils;
 
@@ -239,6 +240,10 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
     Map<String, Object> getStringParams(ApiParam apiParam, boolean hasItems) {
         Map<String, Object> parameters;
         parameters = new HashMap<>(20);
+        //add mock value for parameters
+        if (StringUtils.isNotEmpty(apiParam.getValue())) {
+            parameters.put("example", StringUtil.removeDoubleQuotes(apiParam.getValue()));
+        }
         if (!hasItems) {
             parameters.put("name", apiParam.getField());
             parameters.put("description", apiParam.getDesc());
@@ -261,6 +266,9 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
                 }
             }
             parameters.putAll(buildParametersSchema(apiParam));
+        }
+        if (apiParam.getExtensions() != null && !apiParam.getExtensions().isEmpty()){
+            apiParam.getExtensions().entrySet().forEach( e-> parameters.put("x-"+e.getKey(), e.getValue()));
         }
 
         return parameters;

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -192,6 +192,12 @@ public class ParamsBuildHelper extends BaseHelper {
                 if (tagsMap.containsKey(DocTags.SINCE)) {
                     since = tagsMap.get(DocTags.SINCE);
                 }
+                //handle extension
+                Map<String, String> extensions = DocUtil.getCommentsByTag(field.getTagsByName(DocTags.EXTENSION), DocTags.EXTENSION);
+                Map extensionParams = new HashMap();
+                if (extensions != null && !extensions.isEmpty()){
+                    extensions.entrySet().stream().forEach( e -> extensionParams.put(e.getKey(), DocUtil.detectTagValue(e.getValue())));
+                }
 
                 boolean strRequired = false;
                 CustomField.Key key = CustomField.Key.create(docField.getDeclaringClassName(), fieldName);
@@ -296,7 +302,8 @@ public class ParamsBuildHelper extends BaseHelper {
                             .setMaxLength(maxLength)
                             .setDesc(comment.toString())
                             .setRequired(strRequired)
-                            .setVersion(since);
+                            .setVersion(since)
+                            .setExtensions(extensionParams);
                     if (fieldGicName.contains("[]") || fieldGicName.endsWith(">")) {
                         param.setType(DocGlobalConstants.PARAM_TYPE_FILE);
                         param.setDesc(comment.append("(array of file)").toString());
@@ -314,6 +321,7 @@ public class ParamsBuildHelper extends BaseHelper {
                     param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
                     String processedType = processFieldTypeName(isShowJavaType, subTypeName);
                     param.setType(processedType);
+                    param.setExtensions(extensionParams);
                     // handle param
                     commonHandleParam(paramList, param, isRequired, comment.toString(), since, strRequired);
 
@@ -349,6 +357,7 @@ public class ParamsBuildHelper extends BaseHelper {
                     int fieldPid;
                     ApiParam param = ApiParam.of().setField(pre + fieldName).setClassName(className).setPid(pid).setMaxLength(maxLength);
                     param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
+                    param.setExtensions(extensionParams);
                     String processedType;
                     if (fieldGicName.length() == 1) {
                         String gicName = DocGlobalConstants.JAVA_OBJECT_FULLY;
@@ -459,7 +468,8 @@ public class ParamsBuildHelper extends BaseHelper {
                                     .setMaxLength(maxLength)
                                     .setType(DocGlobalConstants.PARAM_TYPE_OBJECT)
                                     .setDesc(DocGlobalConstants.ANY_OBJECT_MSG)
-                                    .setVersion(DocGlobalConstants.DEFAULT_VERSION);
+                                    .setVersion(DocGlobalConstants.DEFAULT_VERSION)
+                                    .setExtensions(extensionParams);
                             paramList.add(param1);
                             continue;
                         }
@@ -525,7 +535,8 @@ public class ParamsBuildHelper extends BaseHelper {
                                 .setMaxLength(maxLength)
                                 .setType(DocGlobalConstants.PARAM_TYPE_OBJECT)
                                 .setDesc(comment.append(" $ref... self").toString())
-                                .setVersion(DocGlobalConstants.DEFAULT_VERSION);
+                                .setVersion(DocGlobalConstants.DEFAULT_VERSION)
+                                .setExtensions(extensionParams);
                         paramList.add(param1);
                     } else {
                         commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -194,9 +194,9 @@ public class ParamsBuildHelper extends BaseHelper {
                 }
                 //handle extension
                 Map<String, String> extensions = DocUtil.getCommentsByTag(field.getTagsByName(DocTags.EXTENSION), DocTags.EXTENSION);
-                Map extensionParams = new HashMap();
+                Map<String, Object> extensionParams = new HashMap<>();
                 if (extensions != null && !extensions.isEmpty()){
-                    extensions.entrySet().stream().forEach( e -> extensionParams.put(e.getKey(), DocUtil.detectTagValue(e.getValue())));
+                    extensions.forEach( (k, v) -> extensionParams.put(k, DocUtil.detectTagValue(v)));
                 }
 
                 boolean strRequired = false;

--- a/src/main/java/com/ly/doc/model/ApiParam.java
+++ b/src/main/java/com/ly/doc/model/ApiParam.java
@@ -21,6 +21,7 @@
 package com.ly.doc.model;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.ly.doc.model.torna.EnumInfo;
@@ -125,6 +126,7 @@ public class ApiParam {
      * Self  Reference loop
      */
     private boolean selfReferenceLoop;
+    private Map<String, Object> extensions;
 
     public static ApiParam of() {
         return new ApiParam();
@@ -311,6 +313,15 @@ public class ApiParam {
         return this;
     }
 
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public ApiParam setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ApiParam{" +
@@ -333,6 +344,7 @@ public class ApiParam {
                 ", maxLength='" + maxLength + '\'' +
                 ", configParam=" + configParam +
                 ", selfReferenceLoop=" + selfReferenceLoop +
+                ", extensions=" + extensions +
                 '}';
     }
 }

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -569,7 +569,9 @@ public class DocUtil {
                 "Please @see " + className;
         return getCommentsByTag(paramTags, tagName, className, tagValNullMsg, tagValErrorMsg);
     }
-
+    public static Map<String, String> getCommentsByTag(List<DocletTag> paramTags, final String tagName){
+        return getCommentsByTag(paramTags, tagName, null, null,null);
+    }
     private static Map<String, String> getCommentsByTag(List<DocletTag> paramTags, final String tagName, String className,
                                                         String tagValNullMsg, String tagValErrorMsg) {
         Map<String, String> paramTagMap = new HashMap<>(16);


### PR DESCRIPTION
add extension in parameters to support openapi extension. And fixed a bug that lake of an example attribute in path parameters and schema properties.
```
/**
 * 资源创建参数
 *
 * @author lidehua
 * @date 2024-02-06
 */
public class OrderAddArg<T> extends Model {

    /**
     * 名称
     * @extension external ignore
     * @mock test...
     */
    private String name;
```
and output the content in openapi.json:
```
{
  "paths":"/xxx": {
      "get": {
       ...
        "parameters": [             
          {
            "schema": {
              "format": "int64",
              "type": "number"
            },
            "in": "query",
            "description": "订单id",
            "x-external": "ignore",
            "required": false,
            "example": "test...",
            "name": "name"
          },
          ...
        ]
      }
    }
}
```
**it include a "example" attribution in parameters** 
It is compatible with openapi specification.