### PR TITLE
Fix non interface documentation in the Solon framework

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -95,6 +95,9 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 
             List<ApiMethodDoc> apiMethodDocs = buildEntryPointMethod(cls, apiConfig, projectBuilder,
                     frameworkAnnotations, configApiReqParams, baseMappingHandler, headerHandler);
+            if (CollectionUtil.isEmpty(apiMethodDocs)) {
+                continue;
+            }
             this.handleApiDoc(cls, apiDocList, apiMethodDocs, order, apiConfig.isMd5EncryptedHtmlName());
         }
         apiDocList = handleTagsApiDoc(apiDocList);


### PR DESCRIPTION
ApiDocList without content will be automatically filtered, which is also effective for springboot