### PR TITLE
If comment is empty, replace it with "undefined"

### DIFF
--- a/src/main/java/com/ly/doc/model/ApiMethodDoc.java
+++ b/src/main/java/com/ly/doc/model/ApiMethodDoc.java
@@ -465,7 +465,7 @@ public class ApiMethodDoc implements IMethod, Serializable, Cloneable {
         if (StringUtil.isNotEmpty(link)) {
             return link;
         }
-        if(StringUtil.isEmpty(desc)) {
+        if (StringUtil.isEmpty(desc)) {
             return "undefined";
         }
         return desc.replace(" ", "_").toLowerCase();

--- a/src/main/java/com/ly/doc/model/ApiMethodDoc.java
+++ b/src/main/java/com/ly/doc/model/ApiMethodDoc.java
@@ -465,6 +465,9 @@ public class ApiMethodDoc implements IMethod, Serializable, Cloneable {
         if (StringUtil.isNotEmpty(link)) {
             return link;
         }
+        if(StringUtil.isEmpty(desc)) {
+            return "undefined";
+        }
         return desc.replace(" ", "_").toLowerCase();
     }
 


### PR DESCRIPTION
When our method does not fill in the description, we hope it can run normally, but currently when the description is empty, a NullPointerException will occur, so I replaced it with undefined when the description is empty.