### PR TITLE
feat: Supports generating descriptions for OpenAPI HTTP error statuses like 404, 500, etc.

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -88,7 +88,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
         Set<OpenApiTag> tags = new HashSet<>();
         json.put("tags", tags);
         json.put("paths", buildPaths(config, apiSchema, tags));
-        json.put("components", buildComponentsSchema(apiSchema.getApiDatas()));
+        json.put("components", buildComponentsSchema(apiSchema));
 
         String filePath = config.getOutPath();
         filePath = filePath + DocGlobalConstants.OPEN_API_JSON;
@@ -195,6 +195,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
         return responseBody;
     }
 
+
     @Override
     List<Map<String, Object>> buildParameters(ApiMethodDoc apiMethodDoc) {
         Map<String, Object> parameters;
@@ -279,9 +280,9 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
     }
 
     @Override
-    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs) {
+    public Map<String, Object> buildComponentsSchema(ApiSchema<ApiDoc> apiSchema) {
         Map<String, Object> schemas = new HashMap<>(4);
-        schemas.put("schemas", buildComponentData(apiDocs));
+        schemas.put("schemas", buildComponentData(apiSchema));
         return schemas;
     }
 }

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -90,7 +90,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
         Set<OpenApiTag> tags = new HashSet<>();
         json.put("tags", tags);
         json.put("paths", buildPaths(config, apiSchema, tags));
-        json.put("definitions", buildComponentsSchema(apiSchema.getApiDatas()));
+        json.put("definitions", buildComponentsSchema(apiSchema));
 
         String filePath = config.getOutPath();
         filePath = filePath + DocGlobalConstants.OPEN_API_JSON;
@@ -271,8 +271,8 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
     }
 
     @Override
-    public Map<String, Object> buildComponentsSchema(List<ApiDoc> apiDocs) {
-        return buildComponentData(apiDocs);
+    public Map<String, Object> buildComponentsSchema(ApiSchema<ApiDoc> apiSchema) {
+        return buildComponentData(apiSchema);
     }
 
 }

--- a/src/main/java/com/ly/doc/constants/SpringMvcAnnotations.java
+++ b/src/main/java/com/ly/doc/constants/SpringMvcAnnotations.java
@@ -60,4 +60,9 @@ public interface SpringMvcAnnotations {
     String SERVER_ENDPOINT = "ServerEndpoint";
 
     String REST_CONTROLLER_ADVICE = "RestControllerAdvice";
+
+    String EXCEPTION_HANDLER = "ExceptionHandler";
+
+    String RESPONSE_STATUS = "ResponseStatus";
+
 }

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -406,6 +406,17 @@ public class ApiConfig {
      */
     private JMeter jmeter;
 
+    /**
+     * Flag to include default HTTP status codes
+     * This field controls whether a default set of HTTP status codes should be included in HTTP responses.
+     * If set to true, a standard set of HTTP status codes (e.g., 200 OK, 404 Not Found) will be automatically
+     * added when handling HTTP responses. If set to false, these status codes will not be automatically added,
+     * requiring manual specification of desired status codes.
+     * The default value is false to avoid unnecessary resource usage where not required.
+     * @since 3.0.5
+     */
+    private boolean addDefaultHttpStatuses;
+
     public static ApiConfig getInstance() {
         return instance;
     }
@@ -1070,5 +1081,13 @@ public class ApiConfig {
 
     public void setJmeter(JMeter jmeter) {
         this.jmeter = jmeter;
+    }
+
+    public boolean isAddDefaultHttpStatuses() {
+        return addDefaultHttpStatuses;
+    }
+
+    public void setAddDefaultHttpStatuses(boolean addDefaultHttpStatuses) {
+        this.addDefaultHttpStatuses = addDefaultHttpStatuses;
     }
 }

--- a/src/main/java/com/ly/doc/model/ApiExceptionStatus.java
+++ b/src/main/java/com/ly/doc/model/ApiExceptionStatus.java
@@ -21,32 +21,93 @@
 
 package com.ly.doc.model;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author yu.sun on 2024/6/9
  * @since 3.0.5
  */
-public class ApiExceptionStatus {
+public class ApiExceptionStatus implements Comparable<ApiExceptionStatus> {
     private String status;
+
+    private String author;
+
+    private String desc;
+
+    private String detail;
+
+    private String responseUsage;
     /**
      * http exception response params
      */
     private List<ApiParam> exceptionResponseParams;
 
+    public static ApiExceptionStatus of() {
+        return new ApiExceptionStatus();
+    }
+
     public String getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public ApiExceptionStatus setStatus(String status) {
         this.status = status;
+        return this;
     }
 
     public List<ApiParam> getExceptionResponseParams() {
         return exceptionResponseParams;
     }
 
-    public void setExceptionResponseParams(List<ApiParam> exceptionResponseParams) {
+    public ApiExceptionStatus setExceptionResponseParams(List<ApiParam> exceptionResponseParams) {
         this.exceptionResponseParams = exceptionResponseParams;
+        return this;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public ApiExceptionStatus setAuthor(String author) {
+        this.author = author;
+        return this;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public ApiExceptionStatus setDesc(String desc) {
+        this.desc = desc;
+        return this;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public ApiExceptionStatus setDetail(String detail) {
+        this.detail = detail;
+        return this;
+    }
+
+    public String getResponseUsage() {
+        return responseUsage;
+    }
+
+    public ApiExceptionStatus setResponseUsage(String responseUsage) {
+        this.responseUsage = responseUsage;
+        return this;
+    }
+
+    @Override
+    public int compareTo(@NotNull ApiExceptionStatus o) {
+        if (Objects.nonNull(o.getDesc())) {
+            return status.compareTo(o.status);
+        }
+        return 0;
     }
 }

--- a/src/main/java/com/ly/doc/model/ExceptionAdviceMethod.java
+++ b/src/main/java/com/ly/doc/model/ExceptionAdviceMethod.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018-2024 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ly.doc.model;
+
+/**
+ * @author yu.sun on 2024/6/9
+ * @since 3.0.5
+ */
+public class ExceptionAdviceMethod{
+
+    private String status;
+
+    private boolean exceptionHandlerMethod;
+
+    public static ExceptionAdviceMethod builder(){
+        return new ExceptionAdviceMethod();
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public ExceptionAdviceMethod setStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    public boolean isExceptionHandlerMethod() {
+        return exceptionHandlerMethod;
+    }
+
+    public ExceptionAdviceMethod setExceptionHandlerMethod(boolean exceptionHandlerMethod) {
+        this.exceptionHandlerMethod = exceptionHandlerMethod;
+        return this;
+    }
+}

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -670,4 +670,14 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
     public boolean isExceptionAdviceEntryPoint(JavaClass javaClass, FrameworkAnnotations frameworkAnnotations) {
         return false;
     }
+
+    @Override
+    public ExceptionAdviceMethod processExceptionAdviceMethod(JavaMethod method) {
+        return null;
+    }
+
+    @Override
+    public List<ApiExceptionStatus> defaultHttpErrorStatuses() {
+        return null;
+    }
 }

--- a/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
@@ -245,4 +245,14 @@ public class SolonDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
     public boolean isExceptionAdviceEntryPoint(JavaClass javaClass, FrameworkAnnotations frameworkAnnotations) {
         return false;
     }
+
+    @Override
+    public ExceptionAdviceMethod processExceptionAdviceMethod(JavaMethod method) {
+        return null;
+    }
+
+    @Override
+    public List<ApiExceptionStatus> defaultHttpErrorStatuses() {
+        return null;
+    }
 }

--- a/src/main/java/com/ly/doc/utils/HttpStatusUtil.java
+++ b/src/main/java/com/ly/doc/utils/HttpStatusUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018-2024 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ly.doc.utils;
+
+/**
+ * @author yu.sun on 2024/6/9
+ * @since 3.0.5
+ */
+public class HttpStatusUtil {
+
+
+    /**
+     * Retrieves the corresponding HTTP status code as a string based on the input status string.
+     * This method maps status strings from the HttpStatus enum to their numeric HTTP status code equivalents.
+     *
+     * @param status The status string from the HttpStatus enum
+     * @return The HTTP status code as a string
+     */
+    public static String getStatusCode(String status) {
+        switch (status) {
+            case "HttpStatus.BAD_REQUEST":
+                return "400";
+            case "HttpStatus.NOT_FOUND":
+                return "404";
+            case "HttpStatus.UNAUTHORIZED":
+                return "401";
+            case "HttpStatus.FORBIDDEN":
+                return "403";
+            case "HttpStatus.METHOD_NOT_ALLOWED":
+                return "405";
+            case "HttpStatus.UNSUPPORTED_MEDIA_TYPE":
+                return "415";
+            default:
+                return "500";
+        }
+    }
+
+    /**
+     * Retrieves the description of an HTTP status based on the input status code string.
+     * This method translates numeric HTTP status codes into human-readable descriptions.
+     *
+     * @param statusCode The HTTP status code as a string
+     * @return The description of the HTTP status
+     */
+    public static String getStatusDescription(String statusCode) {
+        switch (statusCode) {
+            case "200":
+                return "OK";
+            case "400":
+                return "Bad Request";
+            case "404":
+                return "Not Found";
+            case "401":
+                return "Unauthorized";
+            case "403":
+                return "Forbidden";
+            case "405":
+                return "Method Not Allowed";
+            case "415":
+                return "Unsupported Media Type";
+            default:
+                return "Internal Server Error";
+        }
+    }
+}


### PR DESCRIPTION
- Supports scanning and parsing of custom HTTP error statuses defined in SpringBoot's RestControllerAdvice.
- Support for other frameworks will be added in future versions.