### PR TITLE
fix: Generate OpenAPI Paths Object tags do not match

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -173,7 +173,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
         apiDoc.setList(apiMethodDocs);
         apiDocList.add(apiDoc);
 
-        tagSet.add(StringUtils.trim(desc));
+        tagSet.add(StringUtils.trim(apiDoc.getName()));
         for (String tag : tagSet) {
             DocMapping.tagDocPut(tag, apiDoc, null);
             for (ApiMethodDoc methodDoc : apiMethodDocs) {


### PR DESCRIPTION
```yaml
{
  "openapi": "3.1.0",
  "info": {
    "title": "xxx-api-doc",
    "version": "v1.0.0"
  },
  "tags": [
    {
      "name": "ApplicationController",
      "description": "应用服务接口"
  ],
  "paths": {
    "/applications/{id}": {
      "get": {
        "summary": "获取应用信息",
        "deprecated": false,
        "tags": [
          "应用服务接口" #It should be name instead of desc, which will result in duplicate grouping
        ],
        "responses": {
        },
        "operationId": "applications-{id}-GET",
        "parameters": []
      }
    }
  },
}
```
![image](https://github.com/TongchengOpenSource/smart-doc/assets/39112652/0b406829-9d7b-470f-83b3-3074e8523055)
