### PR TITLE
fix(openapi): :bug: support @JsonFormat(shape = JsonFormat.Shape.NUMBER) annotation for enum types example

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -40,7 +40,8 @@ import com.thoughtworks.qdox.JavaProjectBuilder;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.ly.doc.constants.DocGlobalConstants.*;
+import static com.ly.doc.constants.DocGlobalConstants.OPENAPI_2_COMPONENT_KRY;
+import static com.ly.doc.constants.DocGlobalConstants.OPENAPI_3_COMPONENT_KRY;
 
 
 /**
@@ -162,6 +163,7 @@ public abstract class AbstractOpenApiBuilder {
      * @param apiConfig    ApiConfig
      * @param apiMethodDoc Method
      * @param apiDoc       ApiDoc
+     * @param apiExceptionStatuses Exception status list
      * @return Map of path urls
      */
     public Map<String, Object> buildPathUrls(ApiConfig apiConfig, ApiMethodDoc apiMethodDoc, ApiDoc apiDoc, List<ApiExceptionStatus> apiExceptionStatuses) {

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -10,6 +10,8 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * @author <a href="mailto:cqmike0315@gmail.com">chenqi</a>
@@ -17,8 +19,23 @@ import java.util.*;
  */
 public class ParamUtil {
 
+    /**
+     * Handles enum types in API parameters.
+     * <p>
+     * This method is primarily used to process enum types, setting the corresponding parameter type, value, and enumeration information in the ApiParam object.
+     * If the enum has a @JsonFormat annotation with a shape attribute value of NUMBER, the value is processed accordingly.
+     * Additionally, it supports setting mock values for parameters through tag mappings.
+     *
+     * @param param           The ApiParam object, used to store parameter information.
+     * @param javaField       The JavaField object, representing the field of a class, used to obtain the type and other information of the field.
+     * @param builder         The ProjectDocConfigBuilder object, used to obtain configuration information for generating documentation.
+     * @param jsonRequest     A boolean value indicating whether the request is in JSON format, used to determine how to obtain the enum value.
+     * @param tagsMap         A map containing tag names and their descriptions, used to override parameter values with mock data.
+     * @param jsonFormatValue The value of the @JsonFormat annotation's shape attribute, used to handle special cases of numeric enums.
+     * @return Returns the processed JavaClass object representing the enum, or null if the input field is not an enum.
+     */
     public static JavaClass handleSeeEnum(ApiParam param, JavaField javaField, ProjectDocConfigBuilder builder, boolean jsonRequest,
-                                          Map<String, String> tagsMap) {
+                                          Map<String, String> tagsMap, String jsonFormatValue) {
         JavaClass seeEnum = JavaClassUtil.getSeeEnum(javaField, builder);
         if (Objects.isNull(seeEnum)) {
             return null;
@@ -32,6 +49,13 @@ public class ParamUtil {
         param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(value)));
         param.setEnumValues(JavaClassUtil.getEnumValues(seeEnum));
         param.setEnumInfo(JavaClassUtil.getEnumInfo(seeEnum, builder));
+        // If the @JsonFormat annotation's shape attribute value is specified, use it as the parameter value
+        if (StringUtil.isNotEmpty(jsonFormatValue)) {
+            param.setValue(jsonFormatValue);
+            param.setEnumValues(IntStream.rangeClosed(0, param.getEnumValues().size() - 1)
+                    .mapToObj(Integer::toString).collect(Collectors.toList()));
+        }
+        // If the tagsMap contains a mock tag and the value is not empty, use the value of the mock tag as the parameter value
         // Override old value
         if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
             param.setValue(tagsMap.get(DocTags.MOCK));


### PR DESCRIPTION
fix(openapi): :bug: support @JsonFormat(shape = JsonFormat.Shape.NUMBER) annotation for enum types example

- Fixed the issue where examples for enums annotated with @JsonFormat(shape = JsonFormat.Shape.NUMBER) were not displayed as numbers in OpenAPI.
- Handled enum types in API parameters with @JsonFormat annotation.
- Set the corresponding parameter type, value, and enumeration info.
- Processed special cases of numeric enums with @JsonFormat's shape attribute.
- Overridden parameter values with mock data from tag mappings.