### PR TITLE
refactor(build-template): ♻️ utilize ServiceLoader for dynamic loading

### DIFF
--- a/src/main/java/com/ly/doc/builder/AdocDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/AdocDocBuilder.java
@@ -64,7 +64,8 @@ public class AdocDocBuilder {
         config.setParamsDataToTree(false);
         config.setAdoc(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder).getApiDatas();
         if (config.isAllInOne()) {

--- a/src/main/java/com/ly/doc/builder/ApiDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/ApiDocBuilder.java
@@ -61,7 +61,8 @@ public class ApiDocBuilder {
         config.setAdoc(false);
         config.setParamsDataToTree(false);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder).getApiDatas();
         if (config.isAllInOne()) {

--- a/src/main/java/com/ly/doc/builder/DocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/DocBuilderTemplate.java
@@ -285,7 +285,7 @@ public class DocBuilderTemplate extends BaseDocBuilderTemplate {
             ApiDoc apiDoc1 = new ApiDoc();
             int codeIndex = 0;
             if (isOnlyDefaultGroup) {
-                if (apiDocs.size() > 0) {
+                if (!apiDocs.isEmpty()) {
                     codeIndex = apiDocs.get(0).getChildrenApiDocs().size();
                 }
             } else {
@@ -320,7 +320,7 @@ public class DocBuilderTemplate extends BaseDocBuilderTemplate {
             apiDoc1.setChildrenApiDocs(childrenApiDocs);
             apiDoc1.setList(methodDocs);
             if (isOnlyDefaultGroup) {
-                if (apiDocs.size() > 0) {
+                if (!apiDocs.isEmpty()) {
                     apiDocs.get(0).getChildrenApiDocs().add(apiDoc1);
                 }
             } else {
@@ -483,7 +483,8 @@ public class DocBuilderTemplate extends BaseDocBuilderTemplate {
         this.checkAndInitForGetApiData(config);
         config.setMd5EncryptedHtmlName(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         return docBuildTemplate.getApiData(configBuilder).getApiDatas();
     }

--- a/src/main/java/com/ly/doc/builder/HtmlApiDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/HtmlApiDocBuilder.java
@@ -66,7 +66,8 @@ public class HtmlApiDocBuilder {
         builderTemplate.checkAndInit(config, Boolean.TRUE);
         config.setParamsDataToTree(false);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder).getApiDatas();
         builderTemplate.copyJQueryAndCss(config);

--- a/src/main/java/com/ly/doc/builder/JMeterBuilder.java
+++ b/src/main/java/com/ly/doc/builder/JMeterBuilder.java
@@ -64,7 +64,8 @@ public class JMeterBuilder {
         config.setShowJavaType(true);
         config.setParamsDataToTree(Boolean.FALSE);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder).getApiDatas();
         String version = config.isCoverOld() ? "" : "-V" + DateTimeUtil.long2Str(System.currentTimeMillis(), DocGlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM);
@@ -72,7 +73,7 @@ public class JMeterBuilder {
         if (StringUtil.isNotEmpty(config.getProjectName())) {
             docName = config.getProjectName() + version + JMETER_SCRIPT_EXTENSION;
         } else {
-            docName = "jmeter-script"+ version + JMETER_SCRIPT_EXTENSION;
+            docName = "jmeter-script" + version + JMETER_SCRIPT_EXTENSION;
         }
         builderTemplate.buildAllInOne(apiDocList, config, javaProjectBuilder, DocGlobalConstants.JMETER_TPL, docName);
     }

--- a/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
+++ b/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
@@ -192,14 +192,16 @@ public class PostmanJsonBuilder {
     private static BodyBean buildBodyBean(ApiMethodDoc apiMethodDoc) {
         BodyBean bodyBean;
         if (apiMethodDoc.getContentType().contains(MediaType.APPLICATION_JSON)) {
-            bodyBean = new BodyBean(Boolean.FALSE);// Json request
+            // Json request
+            bodyBean = new BodyBean(Boolean.FALSE);
             bodyBean.setMode(convertContentTypeToPostmanType(apiMethodDoc.getContentType()));
             if (apiMethodDoc.getRequestExample() != null) {
                 bodyBean.setRaw(apiMethodDoc.getRequestExample().getJsonBody());
             }
         } else {
             if (apiMethodDoc.getType().equals(Methods.POST.getValue())) {
-                bodyBean = new BodyBean(Boolean.TRUE); // Formdata
+                // Formdata
+                bodyBean = new BodyBean(Boolean.TRUE);
                 bodyBean.setMode(convertContentTypeToPostmanType(apiMethodDoc.getContentType()));
                 if (CollectionUtil.isNotEmpty(apiMethodDoc.getRequestExample().getFormDataList())) {
                     bodyBean.setFormdata(apiMethodDoc.getRequestExample().getFormDataList());
@@ -248,7 +250,8 @@ public class PostmanJsonBuilder {
     }
 
     private static void postManCreate(ApiConfig config, ProjectDocConfigBuilder configBuilder) {
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         config.setShowJavaType(true);
         List<ApiDoc> apiDocList = docBuildTemplate.getApiData(configBuilder).getApiDatas();
@@ -270,13 +273,13 @@ public class PostmanJsonBuilder {
 
     /**
      * Converts the request Content-Type to its corresponding Postman request type.
-     *
+     * <p>
      * Postman is a popular API testing tool that supports various request types. This method aims to map common
      * Content-Types to the formats recognized by Postman, facilitating more accurate HTTP request simulations.
      *
      * @param contentType The MIME type of the data in the request, indicating how it should be processed.
      * @return The Postman request type corresponding to the given Content-Type.
-     *
+     * <p>
      * Note: This mapping covers typical use cases and Postman's supported range; it may not include all possible Content-Types.
      */
     private static String convertContentTypeToPostmanType(String contentType) {

--- a/src/main/java/com/ly/doc/builder/TornaBuilder.java
+++ b/src/main/java/com/ly/doc/builder/TornaBuilder.java
@@ -68,7 +68,8 @@ public class TornaBuilder {
         DocBuilderTemplate builderTemplate = new DocBuilderTemplate();
         builderTemplate.checkAndInit(config, Boolean.FALSE);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         ApiSchema<ApiDoc> apiSchema = docBuildTemplate.getApiData(configBuilder);
         List<ApiDoc> apiDocList = docBuildTemplate.handleApiGroup(apiSchema.getApiDatas(), config);

--- a/src/main/java/com/ly/doc/builder/WordDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/WordDocBuilder.java
@@ -77,7 +77,8 @@ public class WordDocBuilder {
         builderTemplate.checkAndInit(config, Boolean.TRUE);
         config.setParamsDataToTree(false);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         ApiSchema<ApiDoc> apiSchema = docBuildTemplate.getApiData(configBuilder);
         List<ApiDoc> apiDocList = apiSchema.getApiDatas();

--- a/src/main/java/com/ly/doc/builder/javadoc/JavadocDocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/javadoc/JavadocDocBuilderTemplate.java
@@ -27,14 +27,16 @@ import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.FrameworkEnum;
 import com.ly.doc.constants.TemplateVariable;
 import com.ly.doc.factory.BuildTemplateFactory;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDocDict;
+import com.ly.doc.model.ApiErrorCode;
+import com.ly.doc.model.ApiSchema;
 import com.ly.doc.model.javadoc.JavadocApiAllData;
 import com.ly.doc.model.javadoc.JavadocApiDoc;
 import com.ly.doc.template.IDocBuildTemplate;
 import com.ly.doc.utils.BeetlTemplateUtil;
 import com.ly.doc.utils.DocUtil;
 import com.power.common.util.CollectionUtil;
-import com.power.common.util.DateTimeUtil;
 import com.power.common.util.FileUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import org.beetl.core.Template;
@@ -44,6 +46,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * java doc build template.
+ * @author chenchuxin
+ */
 public class JavadocDocBuilderTemplate extends BaseDocBuilderTemplate {
 
     private static final String DEPENDENCY_TITLE = "Add dependency";
@@ -92,7 +98,7 @@ public class JavadocDocBuilderTemplate extends BaseDocBuilderTemplate {
         Template tpl = BeetlTemplateUtil.getByName(template);
         tpl.binding(TemplateVariable.API_DOC_LIST.getVariable(), apiDocList);
         // binding common variable
-        super.bindingCommonVariable(config,javaProjectBuilder,tpl, apiDocList.isEmpty());
+        super.bindingCommonVariable(config, javaProjectBuilder, tpl, apiDocList.isEmpty());
 
         FileUtil.nioWriteFile(tpl.render(), outPath + DocGlobalConstants.FILE_SEPARATOR + outPutFileName);
     }
@@ -176,7 +182,8 @@ public class JavadocDocBuilderTemplate extends BaseDocBuilderTemplate {
         this.checkAndInitForGetApiData(config);
         config.setMd5EncryptedHtmlName(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<JavadocApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<JavadocApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         ApiSchema<JavadocApiDoc> apiSchema = docBuildTemplate.getApiData(configBuilder);
         return apiSchema.getApiDatas();
@@ -185,7 +192,8 @@ public class JavadocDocBuilderTemplate extends BaseDocBuilderTemplate {
     public List<JavadocApiDoc> getJavadocApiDoc(ApiConfig config, JavaProjectBuilder javaProjectBuilder) {
         config.setShowJavaType(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<JavadocApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<JavadocApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         return docBuildTemplate.getApiData(configBuilder).getApiDatas();
     }

--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -572,7 +572,8 @@ public abstract class AbstractOpenApiBuilder {
         builderTemplate.checkAndInit(config, Boolean.TRUE);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, projectBuilder);
         config.setParamsDataToTree(true);
-        IDocBuildTemplate docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         return docBuildTemplate.getApiData(configBuilder);
     }

--- a/src/main/java/com/ly/doc/builder/rpc/RpcDocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcDocBuilderTemplate.java
@@ -35,12 +35,16 @@ import com.ly.doc.model.rpc.RpcApiDoc;
 import com.ly.doc.template.IDocBuildTemplate;
 import com.ly.doc.utils.BeetlTemplateUtil;
 import com.ly.doc.utils.DocUtil;
-import com.power.common.util.*;
+import com.power.common.util.CollectionUtil;
+import com.power.common.util.FileUtil;
+import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import org.beetl.core.Template;
 
-import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author yu 2020/5/16.
@@ -104,7 +108,7 @@ public class RpcDocBuilderTemplate extends BaseDocBuilderTemplate {
         tpl.binding(TemplateVariable.DEPENDENCY_LIST.getVariable(), config.getRpcApiDependencies());
         tpl.binding(TemplateVariable.RPC_CONSUMER_CONFIG.getVariable(), rpcConfigConfigContent);
         // binding common variable
-        super.bindingCommonVariable(config,javaProjectBuilder,tpl, apiDocList.isEmpty());
+        super.bindingCommonVariable(config, javaProjectBuilder, tpl, apiDocList.isEmpty());
         FileUtil.nioWriteFile(tpl.render(), outPath + DocGlobalConstants.FILE_SEPARATOR + outPutFileName);
     }
 
@@ -188,7 +192,8 @@ public class RpcDocBuilderTemplate extends BaseDocBuilderTemplate {
         this.checkAndInitForGetApiData(config);
         config.setMd5EncryptedHtmlName(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<RpcApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<RpcApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         return docBuildTemplate.getApiData(configBuilder).getApiDatas();
     }
@@ -196,7 +201,8 @@ public class RpcDocBuilderTemplate extends BaseDocBuilderTemplate {
     public List<RpcApiDoc> getRpcApiDoc(ApiConfig config, JavaProjectBuilder javaProjectBuilder) {
         config.setShowJavaType(true);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<RpcApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<RpcApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         Objects.requireNonNull(docBuildTemplate, "doc build template is null");
         return docBuildTemplate.getApiData(configBuilder).getApiDatas();
     }

--- a/src/main/java/com/ly/doc/builder/websocket/WebSocketMarkdownBuilder.java
+++ b/src/main/java/com/ly/doc/builder/websocket/WebSocketMarkdownBuilder.java
@@ -60,10 +60,8 @@ public class WebSocketMarkdownBuilder {
         config.setAdoc(false);
         config.setParamsDataToTree(false);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IWebSocketDocBuildTemplate<WebSocketDoc> docBuildTemplate = BuildTemplateFactory.getWebSocketDocBuildTemplate(config.getFramework());
-        if (null == docBuildTemplate) {
-            return;
-        }
+        IWebSocketDocBuildTemplate<WebSocketDoc> docBuildTemplate = BuildTemplateFactory.getWebSocketDocBuildTemplate(
+                config.getFramework(), config.getClassLoader());
         List<WebSocketDoc> webSocketDocList = docBuildTemplate.getWebSocketData(configBuilder);
         if (null == webSocketDocList || webSocketDocList.isEmpty()) {
             return;

--- a/src/main/java/com/ly/doc/constants/FrameworkEnum.java
+++ b/src/main/java/com/ly/doc/constants/FrameworkEnum.java
@@ -22,8 +22,11 @@ package com.ly.doc.constants;
 
 import com.power.common.util.StringUtil;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
- * Smart-doc Supported Framework
+ * Smart-doc Supported Framework.
  *
  * @author yu 2021/6/27.
  */
@@ -82,6 +85,16 @@ public enum FrameworkEnum {
             }
         }
         return className;
+    }
+
+    /**
+     * Get all supported frameworks.
+     *
+     * @return all supported frameworks
+     */
+    public static String allFramework() {
+        return Arrays.stream(FrameworkEnum.values()).map(FrameworkEnum::getFramework)
+                .collect(Collectors.joining(","));
     }
 
 

--- a/src/main/java/com/ly/doc/factory/BuildTemplateFactory.java
+++ b/src/main/java/com/ly/doc/factory/BuildTemplateFactory.java
@@ -26,51 +26,54 @@ import com.ly.doc.model.WebSocketDoc;
 import com.ly.doc.template.IDocBuildTemplate;
 import com.ly.doc.template.IWebSocketDocBuildTemplate;
 
+import java.util.ServiceLoader;
+
 /**
+ * build template factory.
+ *
  * @author yu 2021/6/27.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class BuildTemplateFactory {
 
     /**
-     * Get Doc build template
+     * Get Doc build template.
      *
-     * @param framework framework name
-     * @param <T>       API doc type
+     * @param framework   framework name
+     * @param <T>         API doc type
+     * @param classLoader classLoader
      * @return Implements of IDocBuildTemplate
      */
-    public static <T extends IDoc> IDocBuildTemplate<T> getDocBuildTemplate(String framework) {
-        String className = FrameworkEnum.getClassNameByFramework(framework);
-        try {
-            return (IDocBuildTemplate<T>) Class.forName(className).newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(
-                    "The class=>" + className + " is not found , smart-doc currently supported framework name can only be set in [dubbo, spring,solon,JAX-RS].");
+    public static <T extends IDoc> IDocBuildTemplate<T> getDocBuildTemplate(String framework, ClassLoader classLoader) {
+        ServiceLoader<IDocBuildTemplate> loader = ServiceLoader.load(IDocBuildTemplate.class, classLoader);
+        for (IDocBuildTemplate<T> template : loader) {
+            // if support framework
+            if (template.supportsFramework(framework)) {
+                return template;
+            }
         }
-        return null;
+        throw new RuntimeException(
+                "The framework=>" + framework + " is not found , smart-doc currently supported framework name can only be set in [" + FrameworkEnum.allFramework() + "].");
     }
 
 
     /**
-     * Get Doc build template
+     * Get WebSocket Doc build template.
      *
-     * @param framework framework name
-     * @param <T>       API doc type
+     * @param framework   framework name
+     * @param <T>         API doc type
+     * @param classLoader classLoader
      * @return Implements of IDocBuildTemplate
      */
-    public static <T extends WebSocketDoc> IWebSocketDocBuildTemplate<T> getWebSocketDocBuildTemplate(String framework) {
-        String className = FrameworkEnum.getClassNameByFramework(framework);
-        try {
-            return (IWebSocketDocBuildTemplate<T>) Class.forName(className).newInstance();
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(
-                    "The class=>" + className + " is not found , smart-doc currently supported framework name can only be set in [dubbo, spring,solon,JAX-RS].");
+    public static <T extends WebSocketDoc> IWebSocketDocBuildTemplate<T> getWebSocketDocBuildTemplate(String framework, ClassLoader classLoader) {
+        ServiceLoader<IWebSocketDocBuildTemplate> loader = ServiceLoader.load(IWebSocketDocBuildTemplate.class, classLoader);
+        for (IWebSocketDocBuildTemplate<T> template : loader) {
+            // if support framework
+            if (template.supportsFramework(framework)) {
+                return template;
+            }
         }
-        return null;
+        throw new RuntimeException(
+                "The framework=>" + framework + " is not found , smart-doc currently supported framework name can only be set in [" + FrameworkEnum.allFramework() + "].");
     }
 }

--- a/src/main/java/com/ly/doc/template/IDocBuildBaseTemplate.java
+++ b/src/main/java/com/ly/doc/template/IDocBuildBaseTemplate.java
@@ -49,9 +49,17 @@ import java.util.stream.Collectors;
  */
 public interface IDocBuildBaseTemplate {
 
+    /**
+     * support framework.
+     *
+     * @param framework framework
+     * @return boolean
+     */
+    boolean supportsFramework(String framework);
+
 
     /**
-     * pre render
+     * pre render.
      *
      * @param docBuildHelper docBuildHelper
      */
@@ -60,7 +68,7 @@ public interface IDocBuildBaseTemplate {
     }
 
     /**
-     * handle group api docs
+     * handle group api docs.
      *
      * @param apiDocList list of apiDocList
      * @param apiConfig  ApiConfig apiConfig
@@ -167,14 +175,14 @@ public interface IDocBuildBaseTemplate {
     }
 
     /**
-     * registered annotations
+     * registered annotations.
      *
      * @return registered annotations
      */
     FrameworkAnnotations registeredAnnotations();
 
     /**
-     * is entry point
+     * is entry point.
      *
      * @param javaProjectBuilder javaProjectBuilder
      * @param javaClassName      javaClassName
@@ -198,6 +206,16 @@ public interface IDocBuildBaseTemplate {
         return isEntryPoint(javaClass, registeredAnnotations());
     }
 
+    /**
+     * Determines if a class should be skipped based on configuration and class annotations.
+     * This method is used to decide whether a class should be documented or ignored during the documentation generation process.
+     * It primarily checks the class against the configured package filters and exclusion filters, as well as checks for the presence of an ignore annotation.
+     *
+     * @param apiConfig The API configuration object, containing package filter and exclusion filter settings.
+     * @param javaClass The class object to be checked.
+     * @param frameworkAnnotations The framework annotation object, used to check if the class is an entry point.
+     * @return true if the class should be skipped, otherwise false.
+     */
     default boolean skipClass( ApiConfig apiConfig ,JavaClass javaClass, FrameworkAnnotations frameworkAnnotations) {
         if (StringUtil.isNotEmpty(apiConfig.getPackageFilters())) {
             // from smart config
@@ -212,14 +230,11 @@ public interface IDocBuildBaseTemplate {
         }
         // from tag
         DocletTag ignoreTag = javaClass.getTagByName(DocTags.IGNORE);
-        if (!isEntryPoint(javaClass, frameworkAnnotations) || Objects.nonNull(ignoreTag)) {
-            return true;
-        }
-        return false;
+        return !isEntryPoint(javaClass, frameworkAnnotations) || Objects.nonNull(ignoreTag);
     }
 
     /**
-     * is entry point
+     * is entry point.
      *
      * @param javaClass            javaClass
      * @param frameworkAnnotations frameworkAnnotations

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -35,7 +35,9 @@ import com.ly.doc.model.request.CurlRequest;
 import com.ly.doc.model.request.JaxrsPathMapping;
 import com.ly.doc.model.request.RequestMapping;
 import com.ly.doc.utils.*;
-import com.power.common.util.*;
+import com.power.common.util.CollectionUtil;
+import com.power.common.util.RandomUtil;
+import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.*;
 
 import java.util.*;
@@ -43,10 +45,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.ly.doc.constants.DocTags.IGNORE;
-
 /**
- * Build documents for JAX RS
+ * Build documents for JAX RS.
  *
  * @author Zxq
  * @since 2021/7/15
@@ -62,15 +62,20 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 
 
     @Override
+    public boolean supportsFramework(String framework) {
+        return FrameworkEnum.JAX_RS.getFramework().equalsIgnoreCase(framework);
+    }
+
+
+    @Override
     public ApiSchema<ApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses) {
         ApiConfig apiConfig = projectBuilder.getApiConfig();
         this.headers = apiConfig.getRequestHeaders();
         List<ApiReqParam> configApiReqParams = Stream.of(apiConfig.getRequestHeaders(), apiConfig.getRequestParams()).filter(Objects::nonNull)
                 .flatMap(Collection::stream).collect(Collectors.toList());
         FrameworkAnnotations frameworkAnnotations = this.registeredAnnotations();
-        ApiSchema<ApiDoc> apiSchema = this.processApiData(projectBuilder, frameworkAnnotations,
+        return this.processApiData(projectBuilder, frameworkAnnotations,
                 configApiReqParams, new SpringMVCRequestMappingHandler(), new SpringMVCRequestHeaderHandler(), candidateClasses);
-        return apiSchema;
     }
 
     @Override
@@ -93,6 +98,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
      * @param projectBuilder projectBuilder
      * @return List<ApiMethodDoc>
      */
+    @SuppressWarnings("deprecation")
     private List<ApiMethodDoc> buildControllerMethod(final JavaClass cls, ApiConfig apiConfig,
                                                      ProjectDocConfigBuilder projectBuilder,
                                                      FrameworkAnnotations frameworkAnnotations) {
@@ -231,6 +237,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 
 
     @Override
+    @SuppressWarnings("deprecation")
     public FrameworkAnnotations registeredAnnotations() {
         FrameworkAnnotations annotations = FrameworkAnnotations.builder();
         HeaderAnnotation headerAnnotation = HeaderAnnotation.builder()
@@ -257,6 +264,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean isEntryPoint(JavaClass cls, FrameworkAnnotations frameworkAnnotations) {
         boolean isDefaultEntryPoint = defaultEntryPoint(cls, frameworkAnnotations);
         if (isDefaultEntryPoint) {
@@ -297,6 +305,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
      * @param builder       builder
      * @return ApiMethodReqParam
      */
+    @SuppressWarnings("deprecation")
     private ApiMethodReqParam requestParams(final DocJavaMethod docJavaMethod, ProjectDocConfigBuilder builder) {
         List<ApiParam> paramList = new ArrayList<>();
         List<DocJavaParameter> parameterList = getJavaParameterList(builder, docJavaMethod, null);
@@ -523,6 +532,15 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
                 .setQueryParams(queryParams);
     }
 
+    /**
+     * Constructs an API request example in JSON format based on the provided Java method and API method documentation.
+     *
+     * @param javaMethod        The object representing the Java method, encapsulating method details.
+     * @param apiMethodDoc      Documentation for the API method, detailing its configuration such as type, headers, URL, etc.
+     * @param configBuilder     The configuration builder for the project, used to access project-wide settings like field naming conventions and class information.
+     * @return                  An instance of ApiRequestExample configured with the appropriate URL, example body, and form data if applicable.
+     */
+    @SuppressWarnings("deprecation")
     private ApiRequestExample buildReqJson(DocJavaMethod javaMethod, ApiMethodDoc apiMethodDoc, ProjectDocConfigBuilder configBuilder) {
         String methodType = apiMethodDoc.getType();
         JavaMethod method = javaMethod.getJavaMethod();

--- a/src/main/java/com/ly/doc/template/JavadocDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JavadocDocBuildTemplate.java
@@ -21,25 +21,32 @@
 package com.ly.doc.template;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.DocTags;
-import com.ly.doc.helper.ParamsBuildHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.constants.FrameworkEnum;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.JavadocJavaMethod;
+import com.ly.doc.model.WebSocketDoc;
 import com.ly.doc.model.annotation.FrameworkAnnotations;
 import com.ly.doc.model.javadoc.JavadocApiDoc;
-import com.ly.doc.model.rpc.RpcApiDoc;
-import com.ly.doc.utils.*;
-import com.power.common.util.CollectionUtil;
+import com.ly.doc.utils.DocUtil;
+import com.ly.doc.utils.JavaClassUtil;
 import com.power.common.util.StringUtil;
 import com.power.common.util.ValidateUtil;
-import com.thoughtworks.qdox.model.*;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaType;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static com.ly.doc.constants.DocTags.IGNORE;
-
+/**
+ * javadoc doc build template.
+ *
+ * @author chenchuxin
+ * @since 3.0.5
+ */
 public class JavadocDocBuildTemplate implements IDocBuildTemplate<JavadocApiDoc>, IWebSocketDocBuildTemplate<WebSocketDoc>, IJavadocDocTemplate {
 
     /**
@@ -48,11 +55,17 @@ public class JavadocDocBuildTemplate implements IDocBuildTemplate<JavadocApiDoc>
     private final AtomicInteger ATOMIC_INTEGER = new AtomicInteger(1);
 
     @Override
+    public boolean supportsFramework(String framework) {
+        return FrameworkEnum.JAVADOC.getFramework().equalsIgnoreCase(framework);
+    }
+
+    @Override
     public boolean addMethodModifiers() {
         return true;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public ApiSchema<JavadocApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses) {
         ApiConfig apiConfig = projectBuilder.getApiConfig();
         List<JavadocApiDoc> apiDocList = new ArrayList<>();

--- a/src/main/java/com/ly/doc/template/RpcDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/RpcDocBuildTemplate.java
@@ -23,14 +23,21 @@ package com.ly.doc.template;
 import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.constants.DubboAnnotationConstants;
-import com.ly.doc.model.*;
+import com.ly.doc.constants.FrameworkEnum;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.RpcJavaMethod;
+import com.ly.doc.model.WebSocketDoc;
 import com.ly.doc.model.annotation.FrameworkAnnotations;
-import com.ly.doc.model.javadoc.JavadocApiDoc;
 import com.ly.doc.model.rpc.RpcApiDoc;
-import com.ly.doc.utils.*;
+import com.ly.doc.utils.DocUtil;
+import com.ly.doc.utils.JavaClassUtil;
 import com.power.common.util.StringUtil;
 import com.power.common.util.ValidateUtil;
-import com.thoughtworks.qdox.model.*;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.expression.AnnotationValue;
 
 import java.util.*;
@@ -39,10 +46,16 @@ import java.util.stream.Collectors;
 
 
 /**
+ * (Apache Dubbo) rpc doc build template.
+ *
  * @author yu 2020/1/29.
  */
 public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IWebSocketDocBuildTemplate<WebSocketDoc>, IRpcDocTemplate {
 
+    @Override
+    public boolean supportsFramework(String framework) {
+        return FrameworkEnum.DUBBO.getFramework().equalsIgnoreCase(framework);
+    }
 
     @Override
     public boolean addMethodModifiers() {
@@ -55,6 +68,7 @@ public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IWebSo
     private final AtomicInteger ATOMIC_INTEGER = new AtomicInteger(1);
 
     @Override
+    @SuppressWarnings("unchecked")
     public ApiSchema<RpcApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses) {
         ApiConfig apiConfig = projectBuilder.getApiConfig();
         List<RpcApiDoc> apiDocList = new ArrayList<>();

--- a/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
@@ -38,9 +38,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
+ * solon doc build template.
+ *
  * @author noear 2022/2/19 created
  */
 public class SolonDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSocketDocBuildTemplate<WebSocketDoc>, IRestDocTemplate, IWebSocketTemplate {
+
+
+    @Override
+    public boolean supportsFramework(String framework) {
+        return FrameworkEnum.SOLON.getFramework().equalsIgnoreCase(framework);
+    }
+
 
     @Override
     public ApiSchema<ApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses) {
@@ -48,9 +57,8 @@ public class SolonDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
         List<ApiReqParam> configApiReqParams = Stream.of(apiConfig.getRequestHeaders(), apiConfig.getRequestParams()).filter(Objects::nonNull)
                 .flatMap(Collection::stream).collect(Collectors.toList());
         FrameworkAnnotations frameworkAnnotations = registeredAnnotations();
-        ApiSchema<ApiDoc> apiDocList = processApiData(projectBuilder, frameworkAnnotations, configApiReqParams,
+        return this.processApiData(projectBuilder, frameworkAnnotations, configApiReqParams,
                 new SolonRequestMappingHandler(), new SolonRequestHeaderHandler(), candidateClasses);
-        return apiDocList;
     }
 
     @Override

--- a/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
@@ -40,9 +40,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
+ * spring boot doc build template.
+ *
  * @author yu 2019/12/21.
  */
 public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSocketDocBuildTemplate<WebSocketDoc>, IRestDocTemplate, IWebSocketTemplate {
+
+    @Override
+    public boolean supportsFramework(String framework) {
+        return FrameworkEnum.SPRING.getFramework().equalsIgnoreCase(framework);
+    }
 
     @Override
     public ApiSchema<ApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses) {
@@ -50,9 +57,8 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
         List<ApiReqParam> configApiReqParams = Stream.of(apiConfig.getRequestHeaders(), apiConfig.getRequestParams()).filter(Objects::nonNull)
                 .flatMap(Collection::stream).collect(Collectors.toList());
         FrameworkAnnotations frameworkAnnotations = registeredAnnotations();
-        ApiSchema<ApiDoc> apiSchema = this.processApiData(projectBuilder, frameworkAnnotations,
+        return this.processApiData(projectBuilder, frameworkAnnotations,
                 configApiReqParams, new SpringMVCRequestMappingHandler(), new SpringMVCRequestHeaderHandler(), candidateClasses);
-        return apiSchema;
     }
 
     @Override
@@ -253,7 +259,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
     public ExceptionAdviceMethod processExceptionAdviceMethod(JavaMethod method) {
         List<JavaAnnotation> annotations = method.getAnnotations();
         boolean isExceptionHandlerMethod = false;
-        String status = null; //
+        String status = null;
         for (JavaAnnotation annotation : annotations) {
             String annotationName = annotation.getType().getValue();
             if (SpringMvcAnnotations.EXCEPTION_HANDLER.equals(annotationName)) {

--- a/src/main/resources/META-INF/services/com.ly.doc.template.IDocBuildTemplate
+++ b/src/main/resources/META-INF/services/com.ly.doc.template.IDocBuildTemplate
@@ -1,0 +1,5 @@
+com.ly.doc.template.SpringBootDocBuildTemplate
+com.ly.doc.template.JAXRSDocBuildTemplate
+com.ly.doc.template.JavadocDocBuildTemplate
+com.ly.doc.template.RpcDocBuildTemplate
+com.ly.doc.template.SolonDocBuildTemplate

--- a/src/main/resources/META-INF/services/com.ly.doc.template.IWebSocketDocBuildTemplate
+++ b/src/main/resources/META-INF/services/com.ly.doc.template.IWebSocketDocBuildTemplate
@@ -1,0 +1,5 @@
+com.ly.doc.template.SpringBootDocBuildTemplate
+com.ly.doc.template.JAXRSDocBuildTemplate
+com.ly.doc.template.JavadocDocBuildTemplate
+com.ly.doc.template.RpcDocBuildTemplate
+com.ly.doc.template.SolonDocBuildTemplate


### PR DESCRIPTION
Refactored BuildTemplateFactory to use Java's ServiceLoader for dynamic loading of build templates. This change enhances modularity, simplifies maintenance, and eases the addition of new frameworks. Replaced hardcoded class instantiation with service discovery, improving the overall structure. Enhanced error messages to list supported frameworks when an unsupported one is specified.

#840 