### PR TITLE
ci: :construction_worker: Introduce GitHub Actions for CI/CD processes

### DIFF
--- a/.github/workflows/build-and-install-plugin.yml
+++ b/.github/workflows/build-and-install-plugin.yml
@@ -1,0 +1,40 @@
+name: Build and Upload Plugin
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Plugin Repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Build and Install Plugin
+        run: mvn install
+
+      - name: Upload Plugin Artifact
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: smart-doc-maven-jar
+          path: ~/.m2/repository/com/ly/smart-doc
+          if-no-files-found: error
+
+      - name: Trigger Example Project Workflow
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+          -d "{\"event_type\":\"run-plugin\", \"client_payload\": {\"artifact_id\": \"${{ env.artifact_id }}\"}}" \
+          https://api.github.com/repos/smart-doc-group/smart-doc-example-cn/dispatches

--- a/.github/workflows/deploy-to-maven-central.yml
+++ b/.github/workflows/deploy-to-maven-central.yml
@@ -1,0 +1,27 @@
+name: Deploy to Maven Central
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Plugin Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Deploy to Maven Central
+        run: mvn deploy -P release
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/spring-javaformat-validate.yml
+++ b/.github/workflows/spring-javaformat-validate.yml
@@ -8,16 +8,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
 
       - name: Install Maven
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/trigger-example-project-update.yml
+++ b/.github/workflows/trigger-example-project-update.yml
@@ -1,0 +1,17 @@
+name: Trigger Example Project Update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Example Project Update Workflow
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/smart-doc-group/smart-doc-example-cn/dispatches \
+          -d '{"event_type":"update-plugin-version", "client_payload": {"version": "${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
This commit introduces four new GitHub Actions workflows And update version:
-  Build and Install Plugin: Builds the plugin, installs it, packages the artifact, and uploads it.
-  Deploy to Maven Central: Deploys the plugin to Maven Central on release creation.
-  Trigger Example Project Update: Triggers an update in the example project on release publication.
-  Upgrade actions/checkout and actions/setup-java to v4

These workflows automate CI/CD tasks, improve reliability, and streamline the development process.