### PR TITLE
fix: :bug: Fix the issue where the generated interface documentation lacks descriptive information when using `Dubbo RPC` or `@javadoc` tags and overriding a parent class or interface without Javadoc comments.

### DIFF
--- a/src/main/java/com/ly/doc/template/IBaseDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/IBaseDocBuildTemplate.java
@@ -20,32 +20,19 @@
  */
 package com.ly.doc.template;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
-import com.ly.doc.model.*;
-import com.ly.doc.utils.*;
-import com.power.common.util.StringUtil;
-import com.power.common.util.UrlUtil;
 import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.helper.ParamsBuildHelper;
+import com.ly.doc.model.*;
 import com.ly.doc.model.annotation.FrameworkAnnotations;
-import com.thoughtworks.qdox.model.DocletTag;
-import com.thoughtworks.qdox.model.JavaAnnotation;
-import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.JavaParameter;
-import com.thoughtworks.qdox.model.JavaType;
+import com.ly.doc.utils.*;
+import com.power.common.util.StringUtil;
+import com.thoughtworks.qdox.model.*;
+
+import java.util.*;
 
 import static com.ly.doc.constants.DocGlobalConstants.NO_COMMENTS_FOUND;
-import static com.ly.doc.constants.DocTags.*;
 
 /**
  * @author yu3.sun on 2022/10/2
@@ -78,11 +65,7 @@ public interface IBaseDocBuildTemplate {
 				&& Objects.isNull(method.getTagByName(DocTags.IGNORE_RESPONSE_BODY_ADVICE))) {
 			String responseBodyAdvice = projectBuilder.getApiConfig().getResponseBodyAdvice().getClassName();
 			if (!returnTypeGenericCanonicalName.startsWith(responseBodyAdvice)) {
-				returnTypeGenericCanonicalName = new StringBuffer().append(responseBodyAdvice)
-					.append("<")
-					.append(returnTypeGenericCanonicalName)
-					.append(">")
-					.toString();
+				returnTypeGenericCanonicalName = responseBodyAdvice + "<" + returnTypeGenericCanonicalName + ">";
 			}
 		}
 		Map<String, JavaType> actualTypesMap = docJavaMethod.getActualTypesMap();
@@ -161,7 +144,7 @@ public interface IBaseDocBuildTemplate {
 				javaType = actualTypesMap.get(javaType.getCanonicalName());
 			}
 			apiJavaParameter.setTypeValue(javaType.getValue());
-			String genericCanonicalName = javaType.getGenericCanonicalName();
+			StringBuilder genericCanonicalName = new StringBuilder(javaType.getGenericCanonicalName());
 			String fullyQualifiedName = javaType.getFullyQualifiedName();
 			apiJavaParameter.setFullyQualifiedName(fullyQualifiedName);
 			String genericFullyQualifiedName = javaType.getGenericFullyQualifiedName();
@@ -173,15 +156,15 @@ public interface IBaseDocBuildTemplate {
 			String rewriteClassName = getRewriteClassName(replacementMap, genericFullyQualifiedName, commentClass);
 			// rewrite class
 			if (JavaClassValidateUtil.isClassName(rewriteClassName)) {
-				genericCanonicalName = rewriteClassName;
+				genericCanonicalName = new StringBuilder(rewriteClassName);
 				genericFullyQualifiedName = DocClassUtil.getSimpleName(rewriteClassName);
 			}
-			if (JavaClassValidateUtil.isMvcIgnoreParams(genericCanonicalName,
+			if (JavaClassValidateUtil.isMvcIgnoreParams(genericCanonicalName.toString(),
 					builder.getApiConfig().getIgnoreRequestParams())) {
 				continue;
 			}
 			genericFullyQualifiedName = DocClassUtil.rewriteRequestParam(genericFullyQualifiedName);
-			genericCanonicalName = DocClassUtil.rewriteRequestParam(genericCanonicalName);
+			genericCanonicalName = new StringBuilder(DocClassUtil.rewriteRequestParam(genericCanonicalName.toString()));
 			List<JavaAnnotation> annotations = parameter.getAnnotations();
 			apiJavaParameter.setAnnotations(annotations);
 			for (JavaAnnotation annotation : annotations) {
@@ -192,17 +175,17 @@ public interface IBaseDocBuildTemplate {
 							&& Objects.isNull(javaMethod.getTagByName(DocTags.IGNORE_REQUEST_BODY_ADVICE))) {
 						String requestBodyAdvice = builder.getApiConfig().getRequestBodyAdvice().getClassName();
 						genericFullyQualifiedName = requestBodyAdvice;
-						genericCanonicalName = requestBodyAdvice + "<" + genericCanonicalName + ">";
+						genericCanonicalName = new StringBuilder(requestBodyAdvice + "<" + genericCanonicalName + ">");
 					}
 				}
 			}
 			if (JavaClassValidateUtil.isCollection(genericFullyQualifiedName)
 					|| JavaClassValidateUtil.isArray(genericFullyQualifiedName)) {
-				if (JavaClassValidateUtil.isCollection(genericCanonicalName)) {
-					genericCanonicalName = genericCanonicalName + "<T>";
+				if (JavaClassValidateUtil.isCollection(genericCanonicalName.toString())) {
+					genericCanonicalName.append("<T>");
 				}
 			}
-			apiJavaParameter.setGenericCanonicalName(genericCanonicalName);
+			apiJavaParameter.setGenericCanonicalName(genericCanonicalName.toString());
 			apiJavaParameter.setGenericFullyQualifiedName(genericFullyQualifiedName);
 			apiJavaParameterList.add(apiJavaParameter);
 		}

--- a/src/main/java/com/ly/doc/template/IJavadocDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IJavadocDocTemplate.java
@@ -33,14 +33,27 @@ import com.thoughtworks.qdox.model.*;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.ly.doc.constants.DocTags.DEPRECATED;
 import static com.ly.doc.constants.DocTags.IGNORE;
 
 public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 
+	/**
+	 * Add method modifiers
+	 * @return boolean
+	 */
 	boolean addMethodModifiers();
 
+	/**
+	 * Convert JavaMethod to JavadocJavaMethod
+	 * @param apiConfig ApiConfig
+	 * @param method JavaMethod
+	 * @param actualTypesMap Map
+	 * @return JavadocJavaMethod
+	 */
 	default JavadocJavaMethod convertToJavadocJavaMethod(ApiConfig apiConfig, JavaMethod method,
 			Map<String, JavaType> actualTypesMap) {
 		JavaClass cls = method.getDeclaringClass();
@@ -48,7 +61,7 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 		javadocJavaMethod.setJavaMethod(method);
 		javadocJavaMethod.setName(method.getName());
 		javadocJavaMethod.setActualTypesMap(actualTypesMap);
-		String methodDefine = methodDefinition(method, actualTypesMap);
+		String methodDefine = this.methodDefinition(method, actualTypesMap);
 		String scapeMethod = methodDefine.replaceAll("<", "&lt;");
 		scapeMethod = scapeMethod.replaceAll(">", "&gt;");
 
@@ -83,9 +96,15 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 		return javadocJavaMethod;
 	}
 
+	/**
+	 * Get method definition
+	 * @param method JavaMethod
+	 * @param actualTypesMap Map
+	 * @return String
+	 */
 	default String methodDefinition(JavaMethod method, Map<String, JavaType> actualTypesMap) {
 		StringBuilder methodBuilder = new StringBuilder();
-		if (addMethodModifiers()) {
+		if (this.addMethodModifiers()) {
 			// append method modifiers
 			method.getModifiers().forEach(item -> methodBuilder.append(item).append(" "));
 		}
@@ -102,33 +121,60 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 		return methodBuilder.toString();
 	}
 
+	/**
+	 * Get parent class methods
+	 * @param apiConfig ApiConfig
+	 * @param cls JavaClass
+	 * @return List
+	 */
 	default List<? extends JavadocJavaMethod> getParentsClassMethods(ApiConfig apiConfig, JavaClass cls) {
 		List<JavadocJavaMethod> docJavaMethods = new ArrayList<>();
 		JavaClass parentClass = cls.getSuperJavaClass();
+		// if parent class is not null and not Object
 		if (Objects.nonNull(parentClass) && !JavaTypeConstants.OBJECT_SIMPLE_NAME.equals(parentClass.getSimpleName())) {
 			Map<String, JavaType> actualTypesMap = JavaClassUtil.getActualTypesMap(parentClass);
 			List<JavaMethod> parentMethodList = parentClass.getMethods();
 			for (JavaMethod method : parentMethodList) {
-				docJavaMethods.add(convertToJavadocJavaMethod(apiConfig, method, actualTypesMap));
+				docJavaMethods.add(this.convertToJavadocJavaMethod(apiConfig, method, actualTypesMap));
 			}
-			docJavaMethods.addAll(getParentsClassMethods(apiConfig, parentClass));
+			// add interface methods
+			docJavaMethods.addAll(this.getInterfaceMethods(apiConfig, parentClass));
+			// add parent class methods
+			docJavaMethods.addAll(this.getParentsClassMethods(apiConfig, parentClass));
 		}
 		return docJavaMethods;
 	}
 
+	/**
+	 * Get interface methods
+	 * @param apiConfig ApiConfig
+	 * @param cls JavaClass
+	 * @return List
+	 */
 	default List<? extends JavadocJavaMethod> getInterfaceMethods(ApiConfig apiConfig, JavaClass cls) {
 		List<JavadocJavaMethod> docJavaMethods = new ArrayList<>();
 		for (JavaClass javaInterface : cls.getInterfaces()) {
 			Map<String, JavaType> actualTypesMap = JavaClassUtil.getActualTypesMap(javaInterface);
 			List<JavaMethod> interfaceMethodList = javaInterface.getMethods();
 			for (JavaMethod method : interfaceMethodList) {
-				docJavaMethods.add(convertToJavadocJavaMethod(apiConfig, method, actualTypesMap));
+				docJavaMethods.add(this.convertToJavadocJavaMethod(apiConfig, method, actualTypesMap));
 			}
-			docJavaMethods.addAll(getInterfaceMethods(apiConfig, javaInterface));
+			// add interface methods
+			docJavaMethods.addAll(this.getInterfaceMethods(apiConfig, javaInterface));
 		}
 		return docJavaMethods;
 	}
 
+	/**
+	 * Constructs a list of request parameters.
+	 * @param javaMethod The JavaMethod object, used to extract method information.
+	 * @param builder The ProjectDocConfigBuilder object, containing project configuration
+	 * details.
+	 * @param atomicInteger An AtomicInteger, used to generate unique parameter IDs.
+	 * @param actualTypesMap A map of actual types, used for type replacement.
+	 * @return A List of ApiParam objects representing the request parameters or null if
+	 * no parameters exist.
+	 */
 	default List<ApiParam> requestParams(final JavaMethod javaMethod, ProjectDocConfigBuilder builder,
 			AtomicInteger atomicInteger, Map<String, JavaType> actualTypesMap) {
 		boolean isStrict = builder.getApiConfig().isStrict();
@@ -239,13 +285,25 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 		return paramList;
 	}
 
+	/**
+	 * Builds a list of service methods. This method parses the given Java class, extracts
+	 * methods that meet certain criteria, and generates corresponding JavadocJavaMethod
+	 * objects for them.
+	 * @param cls The Java class to parse.
+	 * @param apiConfig The API configuration object, containing rules for documentation
+	 * generation.
+	 * @param projectBuilder The project documentation configuration builder, used to
+	 * construct project-level documentation configurations.
+	 * @return A list containing documented methods represented as JavadocJavaMethod
+	 * objects.
+	 */
 	default List<? extends JavadocJavaMethod> buildServiceMethod(final JavaClass cls, ApiConfig apiConfig,
 			ProjectDocConfigBuilder projectBuilder) {
-		String clazName = cls.getCanonicalName();
+		String clsCanonicalName = cls.getCanonicalName();
 		List<JavaMethod> methods = cls.getMethods();
 		List<JavadocJavaMethod> methodDocList = new ArrayList<>(methods.size());
 
-		Set<String> filterMethods = DocUtil.findFilterMethods(clazName);
+		Set<String> filterMethods = DocUtil.findFilterMethods(clsCanonicalName);
 		boolean needAllMethods = filterMethods.contains(DocGlobalConstants.DEFAULT_FILTER_METHOD);
 
 		for (JavaMethod method : methods) {
@@ -260,31 +318,51 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 						"Unable to find comment for method " + method.getName() + " in " + cls.getCanonicalName());
 			}
 			if (needAllMethods || filterMethods.contains(method.getName())) {
-				JavadocJavaMethod apiMethodDoc = convertToJavadocJavaMethod(apiConfig, method, null);
+				JavadocJavaMethod apiMethodDoc = this.convertToJavadocJavaMethod(apiConfig, method, null);
 				methodDocList.add(apiMethodDoc);
 			}
 
 		}
-		// add parent class methods
-		methodDocList.addAll(getParentsClassMethods(apiConfig, cls));
-		if (cls.isInterface() || cls.isAbstract()) {
-			methodDocList.addAll(getInterfaceMethods(apiConfig, cls));
-		}
+		// Add parent class methods
+		methodDocList.addAll(this.getParentsClassMethods(apiConfig, cls));
+		// Add interface methods
+		methodDocList.addAll(this.getInterfaceMethods(apiConfig, cls));
 
-		int methodOrder = 0;
-		List<JavadocJavaMethod> javadocJavaMethods = new ArrayList<>(methodDocList.size());
-		for (JavadocJavaMethod method : methodDocList) {
-			methodOrder++;
-			method.setOrder(methodOrder);
-			String methodUid = DocUtil.generateId(clazName + method.getName() + methodOrder);
-			method.setMethodId(methodUid);
-			// build request params
-			List<ApiParam> requestParams = requestParams(method.getJavaMethod(), projectBuilder, new AtomicInteger(0),
-					method.getActualTypesMap());
-			// build response params
-			List<ApiParam> responseParams = buildReturnApiParams(DocJavaMethod.builder()
+		Map<JavadocJavaMethod, List<ApiParam>> methodRequestParams = new HashMap<>(16);
+		Map<JavadocJavaMethod, List<ApiParam>> methodResponseParams = new HashMap<>(16);
+
+		// Construct the method map
+		Map<String, JavadocJavaMethod> methodMap = methodDocList.stream().collect(Collectors.toMap(method -> {
+			// Build request params
+			List<ApiParam> requestParams = this.requestParams(method.getJavaMethod(), projectBuilder,
+					new AtomicInteger(0), method.getActualTypesMap());
+			methodRequestParams.put(method, requestParams);
+			// Build response params
+			List<ApiParam> responseParams = this.buildReturnApiParams(DocJavaMethod.builder()
 				.setJavaMethod(method.getJavaMethod())
 				.setActualTypesMap(method.getActualTypesMap()), projectBuilder);
+			methodResponseParams.put(method, responseParams);
+			String requestParamsStr = Objects.isNull(requestParams) ? "null"
+					: requestParams.stream().map(ApiParam::getFullyTypeName).collect(Collectors.joining("|"));
+
+			String responseParamsString = (Objects.isNull(responseParams) ? "null"
+					: responseParams.stream().map(ApiParam::getFullyTypeName).collect(Collectors.joining("|")));
+			return requestParamsStr + " " + method.getName() + "(" + responseParamsString + ")";
+		},
+
+				Function.identity(), this::mergeJavadocMethods, LinkedHashMap::new));
+
+		int methodOrder = 0;
+		List<JavadocJavaMethod> javadocJavaMethods = new ArrayList<>(methodMap.values().size());
+		for (JavadocJavaMethod method : methodMap.values()) {
+			methodOrder++;
+			method.setOrder(methodOrder);
+			String methodUid = DocUtil.generateId(clsCanonicalName + method.getName() + methodOrder);
+			method.setMethodId(methodUid);
+			// build request params
+			List<ApiParam> requestParams = methodRequestParams.get(method);
+			// build response params
+			List<ApiParam> responseParams = methodResponseParams.get(method);
 			if (apiConfig.isParamsDataToTree()) {
 				method.setRequestParams(ApiParamTreeUtil.apiParamToTree(requestParams));
 				method.setResponseParams(ApiParamTreeUtil.apiParamToTree(responseParams));
@@ -296,6 +374,32 @@ public interface IJavadocDocTemplate extends IBaseDocBuildTemplate {
 			javadocJavaMethods.add(method);
 		}
 		return javadocJavaMethods;
+	}
+
+	/**
+	 * Merges two JavadocJavaMethod objects. If the existing method lacks certain details
+	 * (description, detail, author, version) that the replacement method has, those
+	 * details are copied from the replacement method to the existing method.
+	 * @param existing The existing JavadocJavaMethod object.
+	 * @param replacement The replacement JavadocJavaMethod object.
+	 * @return The merged JavadocJavaMethod object, with details filled in from the
+	 * replacement method if necessary.
+	 */
+	default JavadocJavaMethod mergeJavadocMethods(JavadocJavaMethod existing, JavadocJavaMethod replacement) {
+		// if existing info is empty and replacement info has desc,replace the info
+		if (StringUtil.isEmpty(existing.getDesc()) && StringUtil.isNotEmpty(replacement.getDesc())) {
+			existing.setDesc(replacement.getDesc());
+		}
+		if (StringUtil.isEmpty(existing.getDetail()) && StringUtil.isNotEmpty(replacement.getDetail())) {
+			existing.setDetail(replacement.getDetail());
+		}
+		if (StringUtil.isEmpty(existing.getAuthor()) && StringUtil.isNotEmpty(replacement.getAuthor())) {
+			existing.setAuthor(replacement.getAuthor());
+		}
+		if (StringUtil.isEmpty(existing.getVersion()) && StringUtil.isNotEmpty(replacement.getVersion())) {
+			existing.setVersion(replacement.getVersion());
+		}
+		return existing;
 	}
 
 }


### PR DESCRIPTION
fix: :bug: Fix the issue where the generated interface documentation lacks descriptive information when using `Dubbo RPC` or `@javadoc` tags and overriding a parent class or interface without Javadoc comments.

BREAKING CHANGE: Significant modifications have been made to the template method, which may affect the details of documentation generation. Thorough testing and review are required to ensure the accuracy of the transformation.

[#865](https://github.com/TongchengOpenSource/smart-doc/issues/865)