### PR TITLE
feat(github-actions): set up weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ci"
+
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Configure Dependabot to perform weekly updates for GitHub Actions and Maven dependencies. This ensures that all project dependencies are kept up to date,improving security and compatibility.