### PR TITLE
Ensure Java format validation reports failure explicitly

### DIFF
--- a/.github/workflows/spring-javaformat-validate.yml
+++ b/.github/workflows/spring-javaformat-validate.yml
@@ -21,13 +21,3 @@ jobs:
         run: |
           echo "Executing Spring code format validation"
           mvn spring-javaformat:validate
-        continue-on-error: true
-
-      - name: Check format validation result
-        if: always()
-        run: |
-          echo "Checking format validation result"
-          if [ ${{ steps.format-validation.outcome }} == 'failure' ]; then
-            echo "Spring code format validation failed, please run `spring-javaformat:apply` to fix and resubmit"
-            exit 1
-          fi


### PR DESCRIPTION
Adjust the Java format validation workflow to report failures explicitly during the Spring project setup. Removed the continue-on-error action and the Check format validation result step, as they are no longer needed with the updated logic. This change will now give a clear indication when the format validation fails, requiring contributors to address formatting issues before merging their pull requests.