### PR TITLE
Feat :sparkles: Split transient field serialization into request and response flags

### DIFF
--- a/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
@@ -20,9 +20,10 @@
  */
 package com.ly.doc.helper;
 
-import java.util.*;
-
-import com.ly.doc.constants.*;
+import com.ly.doc.builder.ProjectDocConfigBuilder;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.JSRAnnotationConstants;
+import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.model.ApiConfig;
 import com.ly.doc.model.CustomField;
 import com.ly.doc.model.DocJavaField;
@@ -31,10 +32,11 @@ import com.ly.doc.utils.*;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.RandomUtil;
 import com.power.common.util.StringUtil;
-import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
+
+import java.util.*;
 
 /**
  * @author yu 2019/12/25.
@@ -72,7 +74,6 @@ public class FormDataBuildHelper extends BaseHelper {
 		// Registry class
 		registryClasses.put(className, className);
 		counter++;
-		boolean skipTransientField = apiConfig.isSkipTransientField();
 		boolean requestFieldToUnderline = apiConfig.isRequestFieldToUnderline();
 		boolean responseFieldToUnderline = apiConfig.isResponseFieldToUnderline();
 		String simpleName = DocClassUtil.getSimpleName(className);
@@ -109,9 +110,10 @@ public class FormDataBuildHelper extends BaseHelper {
 					|| JavaClassValidateUtil.isIgnoreFieldTypes(subTypeName)) {
 				continue;
 			}
-			if (field.isTransient() && skipTransientField) {
+			if (field.isTransient() && apiConfig.isSerializeRequestTransients()) {
 				continue;
 			}
+
 			List<JavaAnnotation> javaAnnotations = docField.getAnnotations();
 			for (JavaAnnotation annotation : javaAnnotations) {
 				String simpleAnnotationName = annotation.getType().getValue();

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -152,7 +152,7 @@ public class JsonBuildHelper extends BaseHelper {
 		if (javaClass.isEnum()) {
 			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, Boolean.FALSE)));
 		}
-		boolean skipTransientField = apiConfig.isSkipTransientField();
+
 		StringBuilder data0 = new StringBuilder();
 		JavaClass cls = builder.getClassByName(typeName);
 
@@ -290,9 +290,14 @@ public class JsonBuildHelper extends BaseHelper {
 			// Process each field of the class
 			out: for (DocJavaField docField : fields) {
 				JavaField field = docField.getJavaField();
-				if (field.isTransient() && skipTransientField) {
-					continue;
+				if (field.isTransient()) {
+					boolean passBuild = (apiConfig.isSerializeRequestTransients() && !isResp)
+							|| (apiConfig.isSerializeResponseTransients() && isResp);
+					if (passBuild) {
+						continue;
+					}
 				}
+
 				String fieldName = docField.getFieldName();
 
 				// if ignore fields contains the field name, then skip this field

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -89,7 +89,6 @@ public class ParamsBuildHelper extends BaseHelper {
 		if (registryClasses.containsKey(className) && level > registryClasses.size()) {
 			return paramList;
 		}
-		boolean skipTransientField = apiConfig.isSkipTransientField();
 		boolean isShowJavaType = projectBuilder.getApiConfig().getShowJavaType();
 		boolean requestFieldToUnderline = projectBuilder.getApiConfig().isRequestFieldToUnderline();
 		boolean responseFieldToUnderline = projectBuilder.getApiConfig().isResponseFieldToUnderline();
@@ -176,9 +175,14 @@ public class ParamsBuildHelper extends BaseHelper {
 				String maxLength = JavaFieldUtil.getParamMaxLength(field.getAnnotations());
 				StringBuilder comment = new StringBuilder();
 				comment.append(docField.getComment());
-				if (field.isTransient() && skipTransientField) {
-					continue;
+				if (field.isTransient()) {
+					boolean passBuild = (apiConfig.isSerializeRequestTransients() && !isResp)
+							|| (apiConfig.isSerializeResponseTransients() && isResp);
+					if (passBuild) {
+						continue;
+					}
 				}
+
 				String fieldName = docField.getFieldName();
 				if (Objects.nonNull(fieldNameConvert)) {
 					fieldName = fieldNameConvert.translate(fieldName);

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -193,9 +193,14 @@ public class ApiConfig {
 	private String projectCName;
 
 	/**
-	 * Skip Transient Field
+	 * serialize request transients;default false
 	 */
-	private boolean skipTransientField = true;
+	private boolean serializeRequestTransients = false;
+
+	/**
+	 * serialize response transients;default false
+	 */
+	private boolean serializeResponseTransients = false;
 
 	/**
 	 * @since 1.7.10 default show author
@@ -800,12 +805,22 @@ public class ApiConfig {
 		this.group = group;
 	}
 
-	public boolean isSkipTransientField() {
-		return skipTransientField;
+	public boolean isSerializeRequestTransients() {
+		return serializeRequestTransients;
 	}
 
-	public void setSkipTransientField(boolean skipTransientField) {
-		this.skipTransientField = skipTransientField;
+	public ApiConfig setSerializeRequestTransients(boolean serializeRequestTransients) {
+		this.serializeRequestTransients = serializeRequestTransients;
+		return this;
+	}
+
+	public boolean isSerializeResponseTransients() {
+		return serializeResponseTransients;
+	}
+
+	public ApiConfig setSerializeResponseTransients(boolean serializeResponseTransients) {
+		this.serializeResponseTransients = serializeResponseTransients;
+		return this;
 	}
 
 	public boolean isShowAuthor() {


### PR DESCRIPTION
- Introduced `serializeRequestTransients` and `serializeResponseTransients` with default `false`
- Removed `skipTransientField` as it is no longer needed
- Updated comments to describe the new flags and their default behavior
- Adjusted interface documentation to allow user configuration for transient field serialization



See #899 