### PR TITLE
ci: :construction_worker: run `TornaApiTest` in CI workflow

### DIFF
--- a/.github/workflows/build-and-run-example-project.yml
+++ b/.github/workflows/build-and-run-example-project.yml
@@ -144,6 +144,7 @@ jobs:
               mvn -DskipTests=true smart-doc:openapi
               mvn -DskipTests=true smart-doc:postman
               mvn -DskipTests=true smart-doc:word
+              mvn test -Dtest=com.power.doc.torna.TornaApiTest
               ;;
             dubbo)
               mvn -DskipTests=true smart-doc:rpc-adoc


### PR DESCRIPTION
Add a step in the GitHub CI workflow to execute the TornaApiTest using Maven. This ensures that the tests are executed as part of the build process, providing additional verification before deployment.




Merge this PR after https://github.com/smart-doc-group/smart-doc-example-cn/pull/47 is merged