### PR TITLE
feat: Fix the issue where the JsonValue annotation cannot be used on an enum.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
             <version>1.4.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github.shalousun</groupId>
+            <groupId>io.github.shalousun</groupId>
             <artifactId>common-util</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
@@ -172,7 +172,7 @@ public class FormDataBuildHelper extends BaseHelper {
 				formDataList.add(formData);
 			}
 			else if (javaClass.isEnum()) {
-				Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.TRUE);
 				if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
 					value = ParamUtil.formatMockValue(tagsMap.get(DocTags.MOCK));
 				}

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -59,7 +59,7 @@ public class JsonBuildHelper extends BaseHelper {
 		}
 		if (method.getReturns().isEnum() && Objects.isNull(responseBodyAdvice)) {
 			return StringUtil
-				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), Boolean.FALSE)));
+				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), builder, Boolean.FALSE)));
 		}
 		if (method.getReturns().isPrimitive() && Objects.isNull(responseBodyAdvice)) {
 			String typeName = method.getReturnType().getCanonicalName();
@@ -150,7 +150,8 @@ public class JsonBuildHelper extends BaseHelper {
 
 		// Handle enum types
 		if (javaClass.isEnum()) {
-			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, Boolean.FALSE)));
+			return StringUtil
+				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE)));
 		}
 
 		StringBuilder data0 = new StringBuilder();
@@ -493,7 +494,7 @@ public class JsonBuildHelper extends BaseHelper {
 								}
 								JavaClass arraySubClass = builder.getJavaProjectBuilder().getClassByName(gicName);
 								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, Boolean.FALSE);
+									Object value = JavaClassUtil.getEnumValue(arraySubClass, builder, Boolean.FALSE);
 									data0.append("[").append(value).append("],");
 									continue;
 								}
@@ -603,7 +604,7 @@ public class JsonBuildHelper extends BaseHelper {
 							// if has Annotation @JsonSerialize And using
 							// ToStringSerializer && isResp
 							else if (toStringSerializer && isResp) {
-								Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
 								data0.append(value).append(",");
 							}
 							// if has @JsonFormat
@@ -611,7 +612,7 @@ public class JsonBuildHelper extends BaseHelper {
 								data0.append(jsonFormatString).append(",");
 							}
 							else {
-								Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
 								data0.append(value).append(",");
 							}
 						}

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -520,7 +520,8 @@ public class ParamsBuildHelper extends BaseHelper {
 							if (!simpleName.equals(gName)) {
 								JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
 								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, Boolean.FALSE);
+									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder,
+											Boolean.FALSE);
 									param.setValue("[\"" + value + "\"]")
 										.setEnumInfo(JavaClassUtil.getEnumInfo(arraySubClass, projectBuilder))
 										.setEnumValues(JavaClassUtil.getEnumValues(arraySubClass));

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1064,7 +1064,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				}
 				JavaClass gicJavaClass = builder.getJavaProjectBuilder().getClassByName(gicName);
 				if (gicJavaClass.isEnum()) {
-					Object value = JavaClassUtil.getEnumValue(gicJavaClass, Boolean.TRUE);
+					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder, Boolean.TRUE);
 					ApiParam param = ApiParam.of()
 						.setField(paramName)
 						.setDesc(comment + ",[array of enum]")
@@ -1209,7 +1209,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			// param is enum
 			else if (javaClass.isEnum()) {
 				String enumName = JavaClassUtil.getEnumParams(javaClass);
-				Object value = JavaClassUtil.getEnumValue(javaClass, isPathVariable || queryParam);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder, isPathVariable || queryParam);
 				if (Boolean.TRUE.equals(builder.getApiConfig().getInlineEnum())) {
 					comment.append("<br/>[Enum: ").append(StringUtil.removeQuotes(enumName)).append("]");
 				}
@@ -1399,7 +1399,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (pathParamsMap.containsKey(paramName)) {
@@ -1412,7 +1412,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (queryParamsMap.containsKey(paramName)) {
@@ -1486,7 +1486,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				String value;
 				JavaClass javaClass1 = configBuilder.getClassByName(gicName);
 				if (Objects.nonNull(javaClass1) && javaClass1.isEnum()) {
-					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, Boolean.TRUE));
+					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, configBuilder, Boolean.TRUE));
 				}
 				else {
 					value = RandomUtil.randomValueByType(gicName);
@@ -1503,7 +1503,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 			else if (javaClass.isEnum()) {
 				// do nothing
-				Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+				Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
 				String strVal = StringUtil.removeQuotes(String.valueOf(value));
 				FormData formData = new FormData();
 				formData.setKey(paramName);

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -401,7 +401,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 				}
 				JavaClass gicJavaClass = builder.getJavaProjectBuilder().getClassByName(gicName);
 				if (gicJavaClass.isEnum()) {
-					Object value = JavaClassUtil.getEnumValue(gicJavaClass, Boolean.TRUE);
+					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder, Boolean.TRUE);
 					ApiParam param = ApiParam.of()
 						.setField(paramName)
 						.setDesc(comment + ",[array of enum]")
@@ -511,7 +511,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 			// param is enum
 			else if (javaClass.isEnum()) {
 				String o = JavaClassUtil.getEnumParams(javaClass);
-				Object value = JavaClassUtil.getEnumValue(javaClass, true);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder, true);
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
 					.setId(paramList.size() + 1)
@@ -615,7 +615,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 							|| JakartaJaxrsAnnotations.JAXB_REST_PATH_FULLY.equals(annotationName)
 							|| JAXRSAnnotations.JAX_PATH_PARAM_FULLY.equals(annotationName)) {
 						if (javaClass.isEnum()) {
-							Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+							Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
 							mockValue = StringUtil.removeQuotes(String.valueOf(value));
 						}
 						pathParamsMap.put(paramName, mockValue);
@@ -666,7 +666,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 					}
 					else if (javaClass.isEnum()) {
 						// do nothing
-						Object value = JavaClassUtil.getEnumValue(javaClass, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
 						String strVal = StringUtil.removeQuotes(String.valueOf(value));
 						FormData formData = new FormData();
 						formData.setDescription(comment);

--- a/src/main/java/com/ly/doc/utils/JavaClassUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassUtil.java
@@ -312,7 +312,7 @@ public class JavaClassUtil {
 	 * @param formDataEnum is return method
 	 * @return Object
 	 */
-	public static Object getEnumValue(JavaClass javaClass, boolean formDataEnum) {
+	public static Object getEnumValue(JavaClass javaClass, ProjectDocConfigBuilder builder, boolean formDataEnum) {
 		List<JavaField> javaFields = javaClass.getEnumConstants();
 		if (Objects.isNull(javaFields)) {
 			throw new RuntimeException(javaClass.getName() + " enum not existed");
@@ -331,6 +331,23 @@ public class JavaClassUtil {
 				}
 			}
 		}
+		if (Objects.nonNull(methodName)) {
+			ApiConfig apiConfig = builder.getApiConfig();
+			ClassLoader classLoader = apiConfig.getClassLoader();
+			Class<?> enumClass = null;
+			try {
+				if (Objects.nonNull(classLoader)) {
+					enumClass = classLoader.loadClass(javaClass.getFullyQualifiedName());
+				}
+				else {
+					enumClass = Class.forName(javaClass.getFullyQualifiedName());
+				}
+			}
+			catch (ClassNotFoundException e) {
+				e.printStackTrace();
+			}
+			return EnumUtil.getFieldValueByMethod(enumClass, methodName);
+		}
 		Object value = null;
 		int index = 0;
 		for (JavaField javaField : javaFields) {
@@ -342,13 +359,7 @@ public class JavaClassUtil {
 				return value;
 			}
 			if (!JavaClassValidateUtil.isPrimitive(simpleName) && index < 1) {
-				if (CollectionUtil.isNotEmpty(javaField.getEnumConstantArguments()) && Objects.nonNull(methodName)) {
-					// enum serialize while use JsonValue
-					value = javaField.getEnumConstantArguments().get(0);
-				}
-				else {
-					value = valueBuilder.toString();
-				}
+				value = valueBuilder.toString();
 			}
 			index++;
 		}

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -52,7 +52,7 @@ public class ParamUtil {
 				javaField.getType().getGenericFullyQualifiedName())) {
 			param.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 		}
-		Object value = JavaClassUtil.getEnumValue(seeEnum, !jsonRequest);
+		Object value = JavaClassUtil.getEnumValue(seeEnum, builder, !jsonRequest);
 		param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(value)));
 		param.setEnumValues(JavaClassUtil.getEnumValues(seeEnum));
 		param.setEnumInfo(JavaClassUtil.getEnumInfo(seeEnum, builder));


### PR DESCRIPTION
```
public enum TrainJobType {
    TRAIN_TENSORFLOW_JOB( "train-tensorflow-job"),
    TRAIN_PYTORCH_JOB("train-pytorch-job");

    private final String value;

    TrainJobType(String value) {
        this.value = value;
    }
    @JsonValue
    public String getValue() {
        return value;
    }
}

```

- The `@JsonValue` annotation is applied to the getValue() method. This means that when an instance of TrainJobType is serialized to JSON, the value returned by getValue() is used.

- For example, if you serialize `TrainJobType.TRAIN_TENSORFLOW_JOB`, the resulting JSON would be `train-tensorflow-job`.