### PR TITLE
feat(params): add support for nested map parameter handling

### DIFF
--- a/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
+++ b/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
@@ -29,6 +29,9 @@ import java.nio.file.FileSystems;
  */
 public interface DocGlobalConstants {
 
+	/**
+	 * api order.
+	 */
 	int API_ORDER = 0;
 
 	/**
@@ -605,5 +608,10 @@ public interface DocGlobalConstants {
 	 * asciidoc extension.
 	 */
 	String ASCIIDOC_EXTENSION = ".adoc";
+
+	/**
+	 * default map key desc.
+	 */
+	String DEFAULT_MAP_KEY_DESC = "A map key.";
 
 }

--- a/src/main/java/com/ly/doc/model/grpc/ProtoInfo.java
+++ b/src/main/java/com/ly/doc/model/grpc/ProtoInfo.java
@@ -87,7 +87,7 @@ public class ProtoInfo implements Serializable {
 		String os = System.getProperty("os.name").toLowerCase();
 		String arch = System.getProperty("os.arch").toLowerCase();
 
-		log.info("The os.name is:" + os + "and os.arch is: " + arch);
+		log.info("The [os.name] is:" + os + ";[os.arch] is: " + arch);
 
 		this.setTargetJsonDirectoryPath(targetJsonPath);
 		this.setJsonName("combined.json");

--- a/src/main/java/com/ly/doc/template/GRpcDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/GRpcDocBuildTemplate.java
@@ -35,6 +35,7 @@ import com.ly.doc.model.grpc.GrpcApiDoc;
 import com.ly.doc.model.grpc.GrpcJavaMethod;
 import com.ly.doc.model.grpc.ProtoInfo;
 import com.ly.doc.model.grpc.proto.*;
+import com.ly.doc.utils.DocUtil;
 import com.power.common.util.FileUtil;
 import com.thoughtworks.qdox.model.JavaClass;
 
@@ -415,8 +416,7 @@ public class GRpcDocBuildTemplate implements IDocBuildTemplate<GrpcApiDoc>, IJav
 			}
 			// field name; if level is 0, it's the root message; otherwise, it's a nested
 			// message
-			String fieldName = level <= 0 ? field.getName()
-					: this.getIndent(level) + DocGlobalConstants.PARAM_PREFIX + field.getName();
+			String fieldName = level <= 0 ? field.getName() : DocUtil.getIndentByLevel(level) + field.getName();
 			ApiParam apiParam = ApiParam.of()
 				.setField(fieldName)
 				.setType(fieldType)
@@ -440,19 +440,6 @@ public class GRpcDocBuildTemplate implements IDocBuildTemplate<GrpcApiDoc>, IJav
 			}
 		}
 		return apiParams;
-	}
-
-	/**
-	 * Generate indent string based on level.
-	 * @param level the nesting level
-	 * @return the indent string
-	 */
-	private String getIndent(int level) {
-		StringBuilder indentBuilder = new StringBuilder();
-		for (int i = 0; i < level; i++) {
-			indentBuilder.append(DocGlobalConstants.FIELD_SPACE);
-		}
-		return indentBuilder.toString();
 	}
 
 	/**

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1190,7 +1190,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 							.setClassName(gicNameArr[1])
 							.setDesc(Optional.ofNullable(builder.getClassByName(gicNameArr[1]))
 								.map(JavaClass::getComment)
-								.orElse("A map key."))
+								.orElse(DocGlobalConstants.DEFAULT_MAP_KEY_DESC))
 							.setVersion(DocGlobalConstants.DEFAULT_VERSION)
 							.setId(paramList.size() + 1);
 						paramList.add(apiParam);

--- a/src/main/java/com/ly/doc/template/JavadocDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JavadocDocBuildTemplate.java
@@ -47,8 +47,8 @@ import java.util.stream.Collectors;
  * @author chenchuxin
  * @since 3.0.5
  */
-public class JavadocDocBuildTemplate
-		implements IDocBuildTemplate<JavadocApiDoc>, IWebSocketDocBuildTemplate<WebSocketDoc>, IJavadocDocTemplate {
+public class JavadocDocBuildTemplate implements IDocBuildTemplate<JavadocApiDoc>,
+		IWebSocketDocBuildTemplate<WebSocketDoc>, IJavadocDocTemplate<JavadocJavaMethod> {
 
 	/**
 	 * api index
@@ -71,7 +71,6 @@ public class JavadocDocBuildTemplate
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public ApiSchema<JavadocApiDoc> renderApi(ProjectDocConfigBuilder projectBuilder,
 			Collection<JavaClass> candidateClasses) {
 		ApiConfig apiConfig = projectBuilder.getApiConfig();
@@ -89,8 +88,7 @@ public class JavadocDocBuildTemplate
 				maxOrder = Math.max(maxOrder, order);
 				setCustomOrder = true;
 			}
-			List<JavadocJavaMethod> apiMethodDocs = (List<JavadocJavaMethod>) buildServiceMethod(cls, apiConfig,
-					projectBuilder);
+			List<JavadocJavaMethod> apiMethodDocs = this.buildServiceMethod(cls, apiConfig, projectBuilder);
 			this.handleJavaApiDoc(cls, apiDocList, apiMethodDocs, order, projectBuilder);
 		}
 		ApiSchema<JavadocApiDoc> apiSchema = new ApiSchema<>();

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -1712,4 +1712,27 @@ public class DocUtil {
 		return null;
 	}
 
+	/**
+	 * Generate indent string based on level.
+	 * @param level the nesting level
+	 * @return the indent string
+	 */
+	public static StringBuilder getStringBuilderByLevel(int level) {
+		StringBuilder indentBuilder = new StringBuilder();
+		for (int i = 0; i < level; i++) {
+			indentBuilder.append(DocGlobalConstants.FIELD_SPACE);
+		}
+		indentBuilder.append(DocGlobalConstants.PARAM_PREFIX);
+		return indentBuilder;
+	}
+
+	/**
+	 * Generate indent string based on level.
+	 * @param level the nesting level
+	 * @return the indent string
+	 */
+	public static String getIndentByLevel(int level) {
+		return getStringBuilderByLevel(level).toString();
+	}
+
 }


### PR DESCRIPTION
Implement the handling of nested map parameters by adding a specific check for map types during parameter building. This enhancement allows the system to process and include nested map parameters properly, improving the overall functionality for complex data structures.


#909 


Example:   https://github.com/smart-doc-group/smart-doc-example-cn/pull/54