### PR TITLE
refactor(utils): add private constructors to prevent instantiation

### DIFF
--- a/src/main/java/com/ly/doc/builder/AdocDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/AdocDocBuilder.java
@@ -43,6 +43,13 @@ public class AdocDocBuilder {
 	private static final String INDEX_DOC = "index.adoc";
 
 	/**
+	 * private constructor
+	 */
+	private AdocDocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build adoc
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/ApiDataBuilder.java
+++ b/src/main/java/com/ly/doc/builder/ApiDataBuilder.java
@@ -32,6 +32,13 @@ import com.thoughtworks.qdox.JavaProjectBuilder;
 public class ApiDataBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private ApiDataBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * Get list of ApiDoc
 	 * @param config ApiConfig
 	 * @return List of ApiDoc

--- a/src/main/java/com/ly/doc/builder/ApiDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/ApiDocBuilder.java
@@ -40,6 +40,13 @@ import java.util.Objects;
 public class ApiDocBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private ApiDocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * @param config ApiConfig
 	 */
 	public static void buildApiDoc(ApiConfig config) {

--- a/src/main/java/com/ly/doc/builder/HtmlApiDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/HtmlApiDocBuilder.java
@@ -48,6 +48,13 @@ public class HtmlApiDocBuilder {
 	private static String INDEX_HTML = "index.html";
 
 	/**
+	 * private constructor
+	 */
+	private HtmlApiDocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/JMeterBuilder.java
+++ b/src/main/java/com/ly/doc/builder/JMeterBuilder.java
@@ -44,6 +44,13 @@ public class JMeterBuilder {
 	private static final String JMETER_SCRIPT_EXTENSION = ".jmx";
 
 	/**
+	 * private constructor
+	 */
+	private JMeterBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * @param config ApiConfig
 	 */
 	public static void buildApiDoc(ApiConfig config) {

--- a/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
+++ b/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
@@ -52,6 +52,13 @@ public class PostmanJsonBuilder {
 	private static final String MSG = "Interface name is not set.";
 
 	/**
+	 * private constructor
+	 */
+	private PostmanJsonBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build postman json
 	 * @param config Smart-doc ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/TornaBuilder.java
+++ b/src/main/java/com/ly/doc/builder/TornaBuilder.java
@@ -48,6 +48,13 @@ import static com.ly.doc.constants.TornaConstants.DEFAULT_GROUP_CODE;
 public class TornaBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private TornaBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api,for unit testing
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/WordDocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/WordDocBuilder.java
@@ -57,6 +57,13 @@ public class WordDocBuilder {
 	private static final String BUILD_DICT_DOCX = "dict.docx";
 
 	/**
+	 * private constructor
+	 */
+	private WordDocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api
 	 * @param config config
 	 * @throws Exception exception

--- a/src/main/java/com/ly/doc/builder/grpc/GrpcAsciidocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/grpc/GrpcAsciidocBuilder.java
@@ -47,6 +47,13 @@ public class GrpcAsciidocBuilder {
 	private static final String INDEX_DOC = "grpc-index.adoc";
 
 	/**
+	 * private constructor
+	 */
+	private GrpcAsciidocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build Asciidoc
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/grpc/GrpcHtmlBuilder.java
+++ b/src/main/java/com/ly/doc/builder/grpc/GrpcHtmlBuilder.java
@@ -42,6 +42,13 @@ public class GrpcHtmlBuilder {
 	private final static String INDEX_HTML = "grpc-index.html";
 
 	/**
+	 * private constructor
+	 */
+	private GrpcHtmlBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build grpc api
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/grpc/GrpcMarkdownBuilder.java
+++ b/src/main/java/com/ly/doc/builder/grpc/GrpcMarkdownBuilder.java
@@ -39,6 +39,13 @@ import java.util.List;
 public class GrpcMarkdownBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private GrpcMarkdownBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build api doc.
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/javadoc/JavadocAdocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/javadoc/JavadocAdocBuilder.java
@@ -35,6 +35,13 @@ public class JavadocAdocBuilder {
 	private static final String INDEX_DOC = "javadoc-index.adoc";
 
 	/**
+	 * private constructor
+	 */
+	private JavadocAdocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build adoc
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/javadoc/JavadocApiDataBuilder.java
+++ b/src/main/java/com/ly/doc/builder/javadoc/JavadocApiDataBuilder.java
@@ -29,6 +29,13 @@ import com.thoughtworks.qdox.JavaProjectBuilder;
 public class JavadocApiDataBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private JavadocApiDataBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * Get list of ApiDoc
 	 * @param config JavadocApiAllData
 	 * @return List of ApiDoc

--- a/src/main/java/com/ly/doc/builder/javadoc/JavadocHtmlBuilder.java
+++ b/src/main/java/com/ly/doc/builder/javadoc/JavadocHtmlBuilder.java
@@ -31,6 +31,13 @@ import java.util.List;
 public class JavadocHtmlBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private JavadocHtmlBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/javadoc/JavadocMarkdownBuilder.java
+++ b/src/main/java/com/ly/doc/builder/javadoc/JavadocMarkdownBuilder.java
@@ -32,6 +32,13 @@ import java.util.List;
 public class JavadocMarkdownBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private JavadocMarkdownBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * @param config ApiConfig
 	 */
 	public static void buildApiDoc(ApiConfig config) {

--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 public class OpenApiBuilder extends AbstractOpenApiBuilder {
 
 	@Override
-	String getModuleName() {
+	public String getModuleName() {
 		return DocGlobalConstants.OPENAPI_3_COMPONENT_KRY;
 	}
 
@@ -172,7 +172,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 	}
 
 	@Override
-	List<Map<String, Object>> buildParameters(ApiMethodDoc apiMethodDoc) {
+	public List<Map<String, Object>> buildParameters(ApiMethodDoc apiMethodDoc) {
 		Map<String, Object> parameters;
 		List<Map<String, Object>> parametersList = new ArrayList<>();
 		// Handling path parameters
@@ -218,7 +218,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 	}
 
 	@Override
-	Map<String, Object> getStringParams(ApiParam apiParam, boolean hasItems) {
+	public Map<String, Object> getStringParams(ApiParam apiParam, boolean hasItems) {
 		Map<String, Object> parameters;
 		parameters = new HashMap<>(20);
 		// add mock value for parameters

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -65,7 +65,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 	}
 
 	@Override
-	String getModuleName() {
+	public String getModuleName() {
 		return DocGlobalConstants.OPENAPI_2_COMPONENT_KRY;
 	}
 
@@ -191,7 +191,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 	}
 
 	@Override
-	List<Map<String, Object>> buildParameters(ApiMethodDoc apiMethodDoc) {
+	public List<Map<String, Object>> buildParameters(ApiMethodDoc apiMethodDoc) {
 		{
 			Map<String, Object> parameters;
 			List<Map<String, Object>> parametersList = new ArrayList<>();
@@ -234,7 +234,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 	}
 
 	@Override
-	Map<String, Object> getStringParams(ApiParam apiParam, boolean hasItems) {
+	public Map<String, Object> getStringParams(ApiParam apiParam, boolean hasItems) {
 		Map<String, Object> parameters;
 		parameters = new HashMap<>(20);
 		if (!hasItems) {

--- a/src/main/java/com/ly/doc/builder/rpc/RpcAdocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcAdocBuilder.java
@@ -38,6 +38,13 @@ public class RpcAdocBuilder {
 	private static final String INDEX_DOC = "rpc-index.adoc";
 
 	/**
+	 * private constructor
+	 */
+	private RpcAdocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build adoc
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/rpc/RpcApiDataBuilder.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcApiDataBuilder.java
@@ -36,6 +36,13 @@ import com.thoughtworks.qdox.JavaProjectBuilder;
 public class RpcApiDataBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private RpcApiDataBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * Get list of ApiDoc
 	 * @param config ApiConfig
 	 * @return List of ApiDoc

--- a/src/main/java/com/ly/doc/builder/rpc/RpcHtmlBuilder.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcHtmlBuilder.java
@@ -34,6 +34,13 @@ import java.util.List;
 public class RpcHtmlBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private RpcHtmlBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/rpc/RpcMarkdownBuilder.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcMarkdownBuilder.java
@@ -35,6 +35,13 @@ import java.util.List;
 public class RpcMarkdownBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private RpcMarkdownBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * @param config ApiConfig
 	 */
 	public static void buildApiDoc(ApiConfig config) {

--- a/src/main/java/com/ly/doc/builder/rpc/RpcTornaBuilder.java
+++ b/src/main/java/com/ly/doc/builder/rpc/RpcTornaBuilder.java
@@ -43,6 +43,13 @@ import java.util.List;
 public class RpcTornaBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private RpcTornaBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build controller api
 	 * @param config config
 	 */

--- a/src/main/java/com/ly/doc/builder/websocket/WebSocketAsciidocBuilder.java
+++ b/src/main/java/com/ly/doc/builder/websocket/WebSocketAsciidocBuilder.java
@@ -47,6 +47,13 @@ public class WebSocketAsciidocBuilder {
 	private static final String INDEX_DOC = "websocket-index.adoc";
 
 	/**
+	 * private constructor
+	 */
+	private WebSocketAsciidocBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build websocket ascii doc.
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/websocket/WebSocketHtmlBuilder.java
+++ b/src/main/java/com/ly/doc/builder/websocket/WebSocketHtmlBuilder.java
@@ -42,6 +42,13 @@ public class WebSocketHtmlBuilder {
 	private final static String INDEX_HTML = "websocket-index.html";
 
 	/**
+	 * private constructor
+	 */
+	private WebSocketHtmlBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build websocket html doc.
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/builder/websocket/WebSocketMarkdownBuilder.java
+++ b/src/main/java/com/ly/doc/builder/websocket/WebSocketMarkdownBuilder.java
@@ -38,6 +38,13 @@ import java.util.List;
 public class WebSocketMarkdownBuilder {
 
 	/**
+	 * private constructor
+	 */
+	private WebSocketMarkdownBuilder() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
 	 * build websocket Markdown doc.
 	 * @param config ApiConfig
 	 */

--- a/src/main/java/com/ly/doc/template/GRpcDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/GRpcDocBuildTemplate.java
@@ -64,7 +64,7 @@ public class GRpcDocBuildTemplate implements IDocBuildTemplate<GrpcApiDoc>, IJav
 	/**
 	 * Logger for the class.
 	 */
-	Logger log = Logger.getLogger(GRpcDocBuildTemplate.class.getName());
+	private final static Logger log = Logger.getLogger(GRpcDocBuildTemplate.class.getName());
 
 	/**
 	 * api index


### PR DESCRIPTION
Add private constructors to utility classes to prevent instantiation and ensure that they are not accidently instantiated when called from other parts of the codebase. This improves the robustness and maintainability of the utility classes.