### PR TITLE
fix:  :bug: Fix empty JSON example value for Map with enum keys and primitive values

### DIFF
--- a/src/main/java/com/ly/doc/constants/DocAnnotationConstants.java
+++ b/src/main/java/com/ly/doc/constants/DocAnnotationConstants.java
@@ -98,6 +98,11 @@ public interface DocAnnotationConstants {
 	String VALUE_PROP = "value";
 
 	/**
+	 * annotation using prop
+	 */
+	String USING_PROP = "using";
+
+	/**
 	 * annotation path prop
 	 */
 	String PATH_PROP = "path";

--- a/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
+++ b/src/main/java/com/ly/doc/constants/DocGlobalConstants.java
@@ -614,4 +614,16 @@ public interface DocGlobalConstants {
 	 */
 	String DEFAULT_MAP_KEY_DESC = "A map key.";
 
+	/**
+	 * object map value warning.
+	 */
+	String OBJECT_MAP_VALUE_WARNING = "{\"warning\":\"Using java.util.Object as a Map value is not recommended. "
+			+ "Smart-doc cannot process it properly. Please use a specific type for better documentation generation.\"}";
+
+	/**
+	 * object list warning.
+	 */
+	String GENERIC_LIST_WARNING = "{\"warning\":\"Using java.util.Object in a List instead of a specific generic type is not recommended. "
+			+ "Smart-doc cannot display the correct generics. Please specify the generic type for better documentation generation.\"}";
+
 }

--- a/src/main/java/com/ly/doc/extension/json/PropertyNamingStrategies.java
+++ b/src/main/java/com/ly/doc/extension/json/PropertyNamingStrategies.java
@@ -20,13 +20,14 @@
  */
 package com.ly.doc.extension.json;
 
+// @formatter:off
 /**
  * copy from jackson and singleton instances.
- *
- * @see <a href=
- * "https://github.com/FasterXML/jackson-databind/blob/2.18/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java">PropertyNamingStrategies</a>.
+ * <p>
+ * <a href="https://github.com/FasterXML/jackson-databind/blob/2.18/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java">PropertyNamingStrategies</a>.
  * @author xingzi
  */
+// @formatter:on
 public abstract class PropertyNamingStrategies implements java.io.Serializable {
 
 	/**

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -192,7 +192,7 @@ public class JsonBuildHelper extends BaseHelper {
 			String gName = JavaClassValidateUtil.isArray(gNameTemp) ? gNameTemp.substring(0, gNameTemp.indexOf("["))
 					: globGicName[0];
 			if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(gName)) {
-				data.append("{\"waring\":\"You may use java.util.Object instead of display generics in the List\"}");
+				data.append(DocGlobalConstants.GENERIC_LIST_WARNING);
 			}
 			else if (JavaClassValidateUtil.isPrimitive(gName)) {
 				data.append(DocUtil.jsonValueByType(gName)).append(",");
@@ -557,10 +557,7 @@ public class JsonBuildHelper extends BaseHelper {
 
 		// when map value is Object
 		if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(gicName)) {
-			data.append("{")
-				.append("\"mapKey\":")
-				.append("{\"waring\":\"You may use java.util.Object for Map value; smart-doc can't be handle.\"}")
-				.append("}");
+			data.append("{").append("\"mapKey\":").append(DocGlobalConstants.OBJECT_MAP_VALUE_WARNING).append("}");
 			return;
 		}
 

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -21,13 +21,13 @@
 package com.ly.doc.helper;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.JavaTypeConstants;
 import com.ly.doc.model.*;
 import com.ly.doc.utils.*;
-import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.*;
-import com.thoughtworks.qdox.model.expression.AnnotationValue;
 
 import java.util.*;
 
@@ -110,31 +110,39 @@ public class JsonBuildHelper extends BaseHelper {
 	 * @param groupClasses A set of valid group classes.
 	 * @param methodJsonViewClasses A set of valid `@JsonView` classes on controller
 	 * method.
-	 * @param builder The project config builder.
+	 * @param projectBuilder The project config projectBuilder.
 	 * @return The JSON string representation of the type.
 	 */
 	public static String buildJson(String typeName, String genericCanonicalName, boolean isResp, int counter,
 			Map<String, String> registryClasses, Set<String> groupClasses, Set<String> methodJsonViewClasses,
-			ProjectDocConfigBuilder builder) {
+			ProjectDocConfigBuilder projectBuilder) {
 
-		Map<String, String> genericMap = new HashMap<>(10);
-		JavaClass javaClass = builder.getJavaProjectBuilder().getClassByName(typeName);
-		ApiConfig apiConfig = builder.getApiConfig();
+		if (StringUtil.isEmpty(typeName)) {
+			throw new RuntimeException("Class name can't be null or empty.");
+		}
+
 		// Check for recursion limit to avoid infinite loops
-		if (counter > apiConfig.getRecursionLimit()) {
+		int recursionLimit = projectBuilder.getApiConfig().getRecursionLimit();
+
+		// Early exit when recursion limit is hit
+		if (counter > recursionLimit) {
 			return "{\"$ref\":\"...\"}";
 		}
 
+		int nextLevel = counter + 1;
 		// Avoid processing the same class multiple times
 		if (registryClasses.containsKey(typeName) && counter > registryClasses.size()) {
 			return "{\"$ref\":\"...\"}";
 		}
 
-		int nextLevel = counter + 1;
+		// Registry class
 		registryClasses.put(typeName, typeName);
 
+		Map<String, String> genericMap = new HashMap<>(10);
+		JavaClass javaClass = projectBuilder.getJavaProjectBuilder().getClassByName(typeName);
+
 		// Check if the class should be ignored based on MVC parameters
-		if (JavaClassValidateUtil.isMvcIgnoreParams(typeName, builder.getApiConfig().getIgnoreRequestParams())) {
+		if (JavaClassValidateUtil.isMvcIgnoreParams(typeName, projectBuilder.getApiConfig().getIgnoreRequestParams())) {
 			if (DocGlobalConstants.MODE_AND_VIEW_FULLY.equals(typeName)) {
 				return "Forward or redirect to a page view.";
 			}
@@ -151,11 +159,11 @@ public class JsonBuildHelper extends BaseHelper {
 		// Handle enum types
 		if (javaClass.isEnum()) {
 			return StringUtil
-				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE)));
+				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE)));
 		}
 
 		StringBuilder result = new StringBuilder();
-		JavaClass cls = builder.getClassByName(typeName);
+		JavaClass cls = projectBuilder.getClassByName(typeName);
 
 		result.append("{");
 		String[] globGicName = DocClassUtil.getSimpleGicName(genericCanonicalName);
@@ -193,7 +201,7 @@ public class JsonBuildHelper extends BaseHelper {
 			else if (gName.contains("<")) {
 				String simple = DocClassUtil.getSimpleName(gName);
 				String json = buildJson(simple, gName, isResp, nextLevel, registryClasses, groupClasses,
-						methodJsonViewClasses, builder);
+						methodJsonViewClasses, projectBuilder);
 				data.append(json);
 			}
 			else if (JavaClassValidateUtil.isCollection(gName)) {
@@ -201,7 +209,7 @@ public class JsonBuildHelper extends BaseHelper {
 			}
 			else {
 				String json = buildJson(gName, gName, isResp, nextLevel, registryClasses, groupClasses,
-						methodJsonViewClasses, builder);
+						methodJsonViewClasses, projectBuilder);
 				data.append(json);
 			}
 			data.append("]");
@@ -210,7 +218,7 @@ public class JsonBuildHelper extends BaseHelper {
 		// Handle map types
 		if (JavaClassValidateUtil.isMap(typeName)) {
 			buildMapJson(genericCanonicalName, isResp, counter, registryClasses, groupClasses, methodJsonViewClasses,
-					builder, data, nextLevel);
+					projectBuilder, data, nextLevel);
 			return data.toString();
 		}
 		// Handle generic object types
@@ -222,28 +230,25 @@ public class JsonBuildHelper extends BaseHelper {
 		// Handle Reactor types
 		else if (JavaClassValidateUtil.isReactor(typeName)) {
 			data.append(buildJson(globGicName[0], typeName, isResp, nextLevel, registryClasses, groupClasses,
-					methodJsonViewClasses, builder));
+					methodJsonViewClasses, projectBuilder));
 			return data.toString();
 		}
 		// Process fields of the class
 		else {
-			boolean requestFieldToUnderline = builder.getApiConfig().isRequestFieldToUnderline();
-			boolean responseFieldToUnderline = builder.getApiConfig().isResponseFieldToUnderline();
+			boolean requestFieldToUnderline = projectBuilder.getApiConfig().isRequestFieldToUnderline();
+			boolean responseFieldToUnderline = projectBuilder.getApiConfig().isResponseFieldToUnderline();
 			List<DocJavaField> fields = JavaClassUtil.getFields(cls, 0, new LinkedHashMap<>(),
-					builder.getApiConfig().getClassLoader());
+					projectBuilder.getApiConfig().getClassLoader());
 
 			// get ignore fields from class
 			Map<String, String> ignoreFields = JavaClassUtil.getClassJsonIgnoreFields(cls);
 
 			// Process each field of the class
-			out: for (DocJavaField docField : fields) {
+			for (DocJavaField docField : fields) {
 				JavaField field = docField.getJavaField();
-				if (field.isTransient()) {
-					boolean passBuild = (apiConfig.isSerializeRequestTransients() && !isResp)
-							|| (apiConfig.isSerializeResponseTransients() && isResp);
-					if (passBuild) {
-						continue;
-					}
+				// ignore transient field
+				if (isTransientField(field, projectBuilder, isResp)) {
+					continue;
 				}
 
 				String fieldName = docField.getFieldName();
@@ -264,97 +269,39 @@ public class JsonBuildHelper extends BaseHelper {
 				// get annotations on the field
 				List<JavaAnnotation> annotations = docField.getAnnotations();
 
-				String jsonFormatString = null;
-				// has Annotation @JsonSerialize And using ToStringSerializer
-				boolean toStringSerializer = false;
-				// Handle @JsonView; if the field is not annotated with @JsonView, skip
-				// it.
-				if (!methodJsonViewClasses.isEmpty() && isResp && annotations.isEmpty()) {
+				// field json annotation
+				FieldJsonAnnotationInfo annotationInfo = getFieldJsonAnnotationInfo(projectBuilder, docField, isResp,
+						groupClasses, methodJsonViewClasses);
+
+				if (Boolean.TRUE.equals(annotationInfo.getIgnore())) {
 					continue;
 				}
-				// Handle annotations on the field
-				for (JavaAnnotation annotation : annotations) {
-					// Handle @JsonView
-					if (JavaClassUtil.shouldExcludeFieldFromJsonView(annotation, methodJsonViewClasses, isResp,
-							builder)) {
-						continue out;
-					}
-
-					String annotationName = annotation.getType().getValue();
-					// if the field is annotated with @JsonSerialize
-					if (DocAnnotationConstants.SHORT_JSON_SERIALIZE.equals(annotationName)
-							&& DocAnnotationConstants.TO_STRING_SERIALIZER_USING
-								.equals(annotation.getNamedParameter("using"))) {
-						toStringSerializer = true;
-						continue;
-					}
-					// if the field is annotated with @Null And isResp is false
-					if (JSRAnnotationConstants.NULL.equals(annotationName) && !isResp) {
-						if (CollectionUtil.isEmpty(groupClasses)) {
-							continue out;
-						}
-						Set<String> groupClassList = JavaClassUtil.getParamGroupJavaClass(annotation);
-						for (String groupClass : groupClassList) {
-							if (groupClasses.contains(groupClass)) {
-								continue out;
-							}
-						}
-					}
-
-					// if the field is annotated with @JsonIgnore || @JsonProperty, then
-					// check if it belongs to the groupClasses
-					if (JavaClassValidateUtil.isIgnoreFieldJson(annotation, isResp)) {
-						continue out;
-					}
-
-					// Handle @JSONField
-					if (DocAnnotationConstants.SHORT_JSON_FIELD.equals(annotationName)) {
-						if (null != annotation.getProperty(DocAnnotationConstants.NAME_PROP)) {
-							fieldName = StringUtil
-								.removeQuotes(annotation.getProperty(DocAnnotationConstants.NAME_PROP).toString());
-						}
-					}
-
-					// Handle @JsonProperty
-					else if (DocAnnotationConstants.SHORT_JSON_PROPERTY.equals(annotationName)
-							|| DocAnnotationConstants.GSON_ALIAS_NAME.equals(annotationName)) {
-						AnnotationValue annotationValue = annotation.getProperty(DocAnnotationConstants.VALUE_PROP);
-						if (null != annotationValue) {
-							fieldName = StringUtil.removeQuotes(annotationValue.toString());
-						}
-					}
-					// Handle @JsonFormat
-					else if (DocAnnotationConstants.JSON_FORMAT.equals(annotationName)) {
-						jsonFormatString = DocUtil.getJsonFormatString(field, annotation);
-					}
+				// the param type from @JsonFormat
+				String fieldJsonFormatType = annotationInfo.getFieldJsonFormatType();
+				// the param value from @JsonFormat
+				String fieldJsonFormatValue = annotationInfo.getFieldJsonFormatValue();
+				// has Annotation @JsonSerialize And using ToStringSerializer
+				boolean toStringSerializer = Boolean.TRUE.equals(annotationInfo.getToStringSerializer());
+				if (Objects.nonNull(annotationInfo.getFieldName())) {
+					fieldName = annotationInfo.getFieldName();
 				}
 
 				String typeSimpleName = docField.getTypeSimpleName();
 				String fieldGicName = docField.getTypeGenericCanonicalName();
 				CustomField.Key key = CustomField.Key.create(docField.getDeclaringClassName(), fieldName);
 
-				CustomField customResponseField = CustomField.nameEquals(key, builder.getCustomRespFieldMap());
-				CustomField customRequestField = CustomField.nameEquals(key, builder.getCustomReqFieldMap());
-				if (Objects.nonNull(customRequestField)) {
-					if (JavaClassUtil.isTargetChildClass(docField.getDeclaringClassName(),
-							customRequestField.getOwnerClassName()) && (customRequestField.isIgnore()) && !isResp) {
-						continue;
-					}
-					else {
-						fieldName = StringUtil.isEmpty(customRequestField.getReplaceName()) ? fieldName
-								: customRequestField.getReplaceName();
-					}
+				CustomField customResponseField = CustomField.nameEquals(key, projectBuilder.getCustomRespFieldMap());
+				CustomField customRequestField = CustomField.nameEquals(key, projectBuilder.getCustomReqFieldMap());
+				CustomFieldInfo customFieldInfo = getCustomFieldInfo(projectBuilder, docField, customResponseField,
+						customRequestField, isResp, typeSimpleName);
+				// ignore custom field
+				if (Boolean.TRUE.equals(customFieldInfo.getIgnore())) {
+					continue;
 				}
-				if (Objects.nonNull(customResponseField)) {
-					if (JavaClassUtil.isTargetChildClass(docField.getDeclaringClassName(),
-							customResponseField.getOwnerClassName()) && (customResponseField.isIgnore()) && isResp) {
-						continue;
-					}
-					else {
-						fieldName = StringUtil.isEmpty(customResponseField.getReplaceName()) ? fieldName
-								: customResponseField.getReplaceName();
-					}
+				if (StringUtil.isNotEmpty(customFieldInfo.getFieldName())) {
+					fieldName = customFieldInfo.getFieldName();
 				}
+
 				fieldName = fieldName.trim();
 				result.append("\"").append(fieldName).append("\":");
 				// get mock value from tag @mock
@@ -371,7 +318,7 @@ public class JsonBuildHelper extends BaseHelper {
 											: DocUtil.handleJsonStr(valueByTypeAndFieldName);
 						}
 						else {
-							fieldValue = StringUtil.isNotEmpty(jsonFormatString) ? jsonFormatString
+							fieldValue = StringUtil.isNotEmpty(fieldJsonFormatValue) ? fieldJsonFormatValue
 									: valueByTypeAndFieldName;
 						}
 					}
@@ -394,7 +341,7 @@ public class JsonBuildHelper extends BaseHelper {
 							result.append(fieldValue).append(",");
 							continue;
 						}
-						if (globGicName.length > 0 && "java.util.List".equals(fieldGicName)) {
+						if (globGicName.length > 0 && JavaTypeConstants.JAVA_LIST_FULLY.equals(fieldGicName)) {
 							fieldGicName = fieldGicName + "<T>";
 						}
 						if (JavaClassValidateUtil.isArray(subTypeName)) {
@@ -424,7 +371,7 @@ public class JsonBuildHelper extends BaseHelper {
 									result.append("[")
 										.append(buildJson(DocClassUtil.getSimpleName(gicName1), gicName1, isResp,
 												nextLevel, registryClasses, groupClasses, methodJsonViewClasses,
-												builder))
+												projectBuilder))
 										.append("]")
 										.append(",");
 								}
@@ -439,9 +386,11 @@ public class JsonBuildHelper extends BaseHelper {
 									result.append("[{\"mapKey\":{}}],");
 									continue;
 								}
-								JavaClass arraySubClass = builder.getJavaProjectBuilder().getClassByName(gicName);
+								JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder()
+									.getClassByName(gicName);
 								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, builder, Boolean.FALSE);
+									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder,
+											Boolean.FALSE);
 									result.append("[").append(value).append("],");
 									continue;
 								}
@@ -449,7 +398,7 @@ public class JsonBuildHelper extends BaseHelper {
 								fieldGicName = DocUtil.formatFieldTypeGicName(genericMap, fieldGicName);
 								result.append("[")
 									.append(buildJson(gicName, fieldGicName, isResp, nextLevel, registryClasses,
-											groupClasses, methodJsonViewClasses, builder))
+											groupClasses, methodJsonViewClasses, projectBuilder))
 									.append("]")
 									.append(",");
 							}
@@ -469,7 +418,7 @@ public class JsonBuildHelper extends BaseHelper {
 							continue;
 						}
 						buildMapJson(fieldGicName, isResp, nextLevel, registryClasses, groupClasses,
-								methodJsonViewClasses, builder, result, nextLevel);
+								methodJsonViewClasses, projectBuilder, result, nextLevel);
 					}
 					else if (fieldGicName.length() == 1) {
 						if (!typeName.equals(genericCanonicalName)) {
@@ -482,7 +431,7 @@ public class JsonBuildHelper extends BaseHelper {
 								String simple = DocClassUtil.getSimpleName(gicName);
 								result
 									.append(buildJson(simple, gicName, isResp, nextLevel, registryClasses, groupClasses,
-											methodJsonViewClasses, builder))
+											methodJsonViewClasses, projectBuilder))
 									.append(",");
 							}
 						}
@@ -514,15 +463,15 @@ public class JsonBuildHelper extends BaseHelper {
 							// if has Annotation @JsonSerialize And using
 							// ToStringSerializer && isResp
 							else if (toStringSerializer && isResp) {
-								Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE);
 								result.append(value).append(",");
 							}
 							// if has @JsonFormat
-							else if (StringUtil.isNotEmpty(jsonFormatString)) {
-								result.append(jsonFormatString).append(",");
+							else if (StringUtil.isNotEmpty(fieldJsonFormatValue)) {
+								result.append(fieldJsonFormatValue).append(",");
 							}
 							else {
-								Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE);
 								result.append(value).append(",");
 							}
 						}
@@ -532,14 +481,14 @@ public class JsonBuildHelper extends BaseHelper {
 							if (toStringSerializer && isResp) {
 								result.append(" ").append(",");
 							}
-							else if (StringUtil.isNotEmpty(jsonFormatString)) {
-								result.append(jsonFormatString).append(",");
+							else if (StringUtil.isNotEmpty(fieldJsonFormatValue)) {
+								result.append(fieldJsonFormatValue).append(",");
 							}
 							else {
 								fieldGicName = DocUtil.formatFieldTypeGicName(genericMap, fieldGicName);
 								result
 									.append(buildJson(subTypeName, fieldGicName, isResp, nextLevel, registryClasses,
-											groupClasses, methodJsonViewClasses, builder))
+											groupClasses, methodJsonViewClasses, projectBuilder))
 									.append(",");
 							}
 						}
@@ -585,13 +534,17 @@ public class JsonBuildHelper extends BaseHelper {
 		String gicName = getKeyValType[1];
 		// when map key is enum
 		if (mapKeyIsEnum) {
+			String mapValueSimpleName = DocClassUtil.getSimpleName(gicName);
+			// Handle primitive types
 			data.append("{");
 			for (JavaField field : mapKeyClass.getFields()) {
 				data.append("\"")
 					.append(field.getName())
 					.append("\":")
-					.append(buildJson(DocClassUtil.getSimpleName(gicName), gicName, isResp, counter + 1,
-							registryClasses, groupClasses, methodJsonViewClasses, builder))
+					.append(JavaClassValidateUtil.isPrimitive(mapValueSimpleName)
+							? DocUtil.jsonValueByType(mapValueSimpleName)
+							: buildJson(mapValueSimpleName, gicName, isResp, counter + 1, registryClasses, groupClasses,
+									methodJsonViewClasses, builder))
 					.append(",");
 			}
 			// Remove the trailing comma

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -23,18 +23,19 @@
 package com.ly.doc.helper;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.JavaTypeConstants;
+import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.extension.json.PropertyNameHelper;
 import com.ly.doc.extension.json.PropertyNamingStrategies;
 import com.ly.doc.model.*;
 import com.ly.doc.utils.*;
 import com.power.common.model.EnumDictionary;
-import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
-import com.thoughtworks.qdox.model.expression.AnnotationValue;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
@@ -73,535 +74,429 @@ public class ParamsBuildHelper extends BaseHelper {
 	public static List<ApiParam> buildParams(String className, String pre, int level, String isRequired, boolean isResp,
 			Map<String, String> registryClasses, ProjectDocConfigBuilder projectBuilder, Set<String> groupClasses,
 			Set<String> methodJsonViewClasses, int pid, boolean jsonRequest, AtomicInteger atomicInteger) {
-		Map<String, String> genericMap = new HashMap<>(10);
 
 		if (StringUtil.isEmpty(className)) {
 			throw new RuntimeException("Class name can't be null or empty.");
 		}
 
-		ClassLoader classLoader = projectBuilder.getApiConfig().getClassLoader();
+		// Recursion limit check cached for efficiency
 		ApiConfig apiConfig = projectBuilder.getApiConfig();
-		int nextLevel = level + 1;
+		int recursionLimit = apiConfig.getRecursionLimit();
+		if (level > recursionLimit) {
+			return Collections.emptyList();
+		}
 
+		int nextLevel = level + 1;
 		// Check circular reference
-		List<ApiParam> paramList = new ArrayList<>();
-		if (level > apiConfig.getRecursionLimit()) {
-			return paramList;
-		}
 		if (registryClasses.containsKey(className) && level > registryClasses.size()) {
-			return paramList;
+			return Collections.emptyList();
 		}
-		boolean isShowJavaType = projectBuilder.getApiConfig().getShowJavaType();
-		boolean requestFieldToUnderline = projectBuilder.getApiConfig().isRequestFieldToUnderline();
-		boolean responseFieldToUnderline = projectBuilder.getApiConfig().isResponseFieldToUnderline();
-		boolean displayActualType = projectBuilder.getApiConfig().isDisplayActualType();
+
 		// Registry class
 		registryClasses.put(className, className);
 		String simpleName = DocClassUtil.getSimpleName(className);
 		String[] globGicName = DocClassUtil.getSimpleGicName(className);
-		JavaClass cls = projectBuilder.getClassByName(simpleName);
+
 		if (Objects.isNull(globGicName) || globGicName.length < 1) {
+			JavaClass cls = projectBuilder.getClassByName(simpleName);
 			// obtain generics from parent class
-			JavaClass superJavaClass = cls != null ? cls.getSuperJavaClass() : null;
-			if (superJavaClass != null
+			JavaClass superJavaClass = Objects.nonNull(cls) ? cls.getSuperJavaClass() : null;
+			if (Objects.nonNull(superJavaClass)
 					&& !JavaTypeConstants.OBJECT_SIMPLE_NAME.equals(superJavaClass.getSimpleName())) {
 				globGicName = DocClassUtil.getSimpleGicName(superJavaClass.getGenericFullyQualifiedName());
 			}
 		}
+
+		boolean isShowJavaType = apiConfig.getShowJavaType();
+
+		// if is primitive
+		if (JavaClassValidateUtil.isPrimitive(simpleName)) {
+			return handlePrimitiveType(simpleName, isShowJavaType, atomicInteger, pid);
+		}
+
+		// Handle collection types
+		if (JavaClassValidateUtil.isCollection(simpleName) || JavaClassValidateUtil.isArray(simpleName)) {
+			return handleCollectionOrArrayType(globGicName, pre, level, isRequired, isResp, registryClasses,
+					projectBuilder, groupClasses, methodJsonViewClasses, pid, jsonRequest, atomicInteger, simpleName);
+		}
+
+		// Handle map types
+		if (JavaClassValidateUtil.isMap(simpleName)) {
+			return buildMapParam(globGicName, pre, level, isRequired, isResp, registryClasses, projectBuilder,
+					groupClasses, methodJsonViewClasses, pid, jsonRequest, nextLevel, atomicInteger);
+		}
+
+		// Handle generic object types
+		if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(className)) {
+			return buildGenericObjectParam(className, pre, isRequired, atomicInteger, pid);
+		}
+
+		// Handle Reactor types
+		if (JavaClassValidateUtil.isReactor(simpleName)) {
+			if (globGicName.length > 0) {
+				return buildParams(globGicName[0], pre, nextLevel, isRequired, isResp, registryClasses, projectBuilder,
+						groupClasses, methodJsonViewClasses, pid, jsonRequest, atomicInteger);
+			}
+			return Collections.emptyList();
+		}
+
+		// handle Class Field
+		return processFields(className, pre, level, isRequired, isResp, registryClasses, projectBuilder, groupClasses,
+				methodJsonViewClasses, pid, jsonRequest, atomicInteger);
+	}
+
+	/**
+	 * Processes fields of a given class and populates a list of API parameters based on
+	 * the field types and properties.
+	 * @param className The name of the class containing the fields.
+	 * @param pre A prefix to prepend to field names.
+	 * @param level The current level of nested fields.
+	 * @param isRequired Indicates if the field is required.
+	 * @param isResp Indicates if the field is part of a response.
+	 * @param registryClasses A map of registry classes used for type resolution.
+	 * @param projectBuilder The project builder used to access project-specific details.
+	 * @param groupClasses A set of group classes relevant to the field processing.
+	 * @param methodJsonViewClasses A set of JSON view classes applicable to methods.
+	 * @param pid The parent ID of the current field.
+	 * @param jsonRequest Indicates if the field is part of a JSON request.
+	 * @param atomicInteger An AtomicInteger used for generating unique IDs.
+	 * @return A list of API parameters representing the processed fields.
+	 */
+	private static List<ApiParam> processFields(String className, String pre, int level, String isRequired,
+			boolean isResp, Map<String, String> registryClasses, ProjectDocConfigBuilder projectBuilder,
+			Set<String> groupClasses, Set<String> methodJsonViewClasses, int pid, boolean jsonRequest,
+			AtomicInteger atomicInteger) {
+
+		if (StringUtil.isEmpty(className)) {
+			throw new RuntimeException("Class name can't be null or empty.");
+		}
+
+		// Check for recursion limit to avoid infinite loops
+		int recursionLimit = projectBuilder.getApiConfig().getRecursionLimit();
+
+		// Early exit when recursion limit is hit
+		if (level > recursionLimit) {
+			return Collections.emptyList();
+		}
+
+		// Avoid processing the same class multiple times
+		if (registryClasses.containsKey(className) && level > registryClasses.size()) {
+			return Collections.emptyList();
+		}
+
+		List<ApiParam> paramList = new ArrayList<>();
+		String simpleName = DocClassUtil.getSimpleName(className);
+
+		JavaClass cls = projectBuilder.getClassByName(simpleName);
+		boolean isShowJavaType = projectBuilder.getApiConfig().getShowJavaType();
+		boolean requestFieldToUnderline = projectBuilder.getApiConfig().isRequestFieldToUnderline();
+		boolean responseFieldToUnderline = projectBuilder.getApiConfig().isResponseFieldToUnderline();
+		boolean displayActualType = projectBuilder.getApiConfig().isDisplayActualType();
+		ClassLoader classLoader = projectBuilder.getApiConfig().getClassLoader();
+
 		PropertyNamingStrategies.NamingBase fieldNameConvert = null;
 		// ignore
 		if (Objects.nonNull(cls)) {
 			List<JavaAnnotation> clsAnnotation = cls.getAnnotations();
 			fieldNameConvert = PropertyNameHelper.translate(clsAnnotation);
 		}
+
+		String[] globGicName = DocClassUtil.getSimpleGicName(className);
+		Map<String, String> genericMap = new HashMap<>(globGicName.length);
 		JavaClassUtil.genericParamMap(genericMap, cls, globGicName);
 
-		if (JavaClassValidateUtil.isPrimitive(simpleName)) {
-			String processedType = processFieldTypeName(isShowJavaType, simpleName);
-			paramList.addAll(primitiveReturnRespComment(processedType, atomicInteger, pid));
-		}
-		else if (JavaClassValidateUtil.isCollection(simpleName) || JavaClassValidateUtil.isArray(simpleName)) {
-			if (!JavaClassValidateUtil.isCollection(globGicName[0])) {
-				String gNameTemp = globGicName[0];
-				String gName = JavaClassValidateUtil.isArray(gNameTemp) ? gNameTemp.substring(0, gNameTemp.indexOf("["))
-						: globGicName[0];
-				if (JavaClassValidateUtil.isPrimitive(gName)) {
-					String processedType = isShowJavaType ? JavaFieldUtil.convertToSimpleTypeName(simpleName)
-							: DocClassUtil.processTypeNameForParams(gName);
-					ApiParam param = ApiParam.of()
-						.setId(atomicOrDefault(atomicInteger, pid + 1))
-						.setField(pre + " -")
-						.setType("array[" + processedType + "]")
-						.setPid(pid)
-						.setDesc("array of " + processedType)
-						.setVersion(DocGlobalConstants.DEFAULT_VERSION)
-						.setRequired(Boolean.parseBoolean(isRequired));
-					paramList.add(param);
-				}
-				else {
-					if (JavaClassValidateUtil.isArray(gNameTemp)) {
-						gNameTemp = gNameTemp.substring(0, gNameTemp.indexOf("["));
-					}
-					paramList.addAll(buildParams(gNameTemp, pre, nextLevel, isRequired, isResp, registryClasses,
-							projectBuilder, groupClasses, methodJsonViewClasses, pid, jsonRequest, atomicInteger));
-				}
+		Map<String, String> ignoreFields = JavaClassUtil.getClassJsonIgnoreFields(cls);
+		List<DocJavaField> fields = JavaClassUtil.getFields(cls, 0, new LinkedHashMap<>(), classLoader);
+		for (DocJavaField docField : fields) {
+			JavaField field = docField.getJavaField();
+			// ignore transient field
+			if (isTransientField(field, projectBuilder, isResp)) {
+				continue;
 			}
-		}
-		else if (JavaClassValidateUtil.isMap(simpleName)) {
-			paramList.addAll(buildMapParam(globGicName, pre, level, isRequired, isResp, registryClasses, projectBuilder,
-					groupClasses, methodJsonViewClasses, pid, jsonRequest, nextLevel, atomicInteger));
-		}
-		else if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(className)) {
-			ApiParam param = ApiParam.of()
-				.setClassName(className)
-				.setId(atomicOrDefault(atomicInteger, pid + 1))
-				.setField(pre + "any object")
-				.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
-				.setPid(pid)
-				.setDesc(DocGlobalConstants.ANY_OBJECT_MSG)
-				.setVersion(DocGlobalConstants.DEFAULT_VERSION)
-				.setRequired(Boolean.parseBoolean(isRequired));
-			paramList.add(param);
-		}
-		else if (JavaClassValidateUtil.isReactor(simpleName)) {
-			if (globGicName.length > 0) {
-				paramList.addAll(buildParams(globGicName[0], pre, nextLevel, isRequired, isResp, registryClasses,
-						projectBuilder, groupClasses, methodJsonViewClasses, pid, jsonRequest, atomicInteger));
+
+			String maxLength = JavaFieldUtil.getParamMaxLength(field.getAnnotations());
+			StringBuilder comment = new StringBuilder();
+			comment.append(docField.getComment());
+
+			String fieldName = docField.getFieldName();
+			if (Objects.nonNull(fieldNameConvert)) {
+				fieldName = fieldNameConvert.translate(fieldName);
 			}
-		}
-		else {
-			Map<String, String> ignoreFields = JavaClassUtil.getClassJsonIgnoreFields(cls);
-			List<DocJavaField> fields = JavaClassUtil.getFields(cls, 0, new LinkedHashMap<>(), classLoader);
-			out: for (DocJavaField docField : fields) {
-				JavaField field = docField.getJavaField();
-				String maxLength = JavaFieldUtil.getParamMaxLength(field.getAnnotations());
-				StringBuilder comment = new StringBuilder();
-				comment.append(docField.getComment());
-				if (field.isTransient()) {
-					boolean passBuild = (apiConfig.isSerializeRequestTransients() && !isResp)
-							|| (apiConfig.isSerializeResponseTransients() && isResp);
-					if (passBuild) {
-						continue;
-					}
+			if (ignoreFields.containsKey(fieldName)) {
+				continue;
+			}
+
+			String subTypeName = docField.getTypeFullyQualifiedName();
+			boolean needToUnderline = (responseFieldToUnderline && isResp) || (requestFieldToUnderline && !isResp);
+			if (needToUnderline) {
+				fieldName = StringUtil.camelToUnderline(fieldName);
+			}
+			String typeSimpleName = field.getType().getSimpleName();
+			String fieldGicName = docField.getTypeGenericCanonicalName();
+			List<JavaAnnotation> javaAnnotations = docField.getAnnotations();
+
+			Map<String, String> tagsMap = DocUtil.getFieldTagsValue(field, docField);
+			// since tag value
+			String since = DocGlobalConstants.DEFAULT_VERSION;
+
+			if (tagsMap.containsKey(DocTags.SINCE)) {
+				since = tagsMap.get(DocTags.SINCE);
+			}
+			// handle extension
+			Map<String, String> extensions = DocUtil.getCommentsByTag(field.getTagsByName(DocTags.EXTENSION),
+					DocTags.EXTENSION);
+			Map<String, Object> extensionParams = new HashMap<>();
+			if (extensions != null && !extensions.isEmpty()) {
+				extensions.forEach((k, v) -> extensionParams.put(k, DocUtil.detectTagValue(v)));
+			}
+
+			boolean strRequired = false;
+			CustomField.Key key = CustomField.Key.create(docField.getDeclaringClassName(), fieldName);
+
+			CustomField customResponseField = CustomField.nameEquals(key, projectBuilder.getCustomRespFieldMap());
+			CustomField customRequestField = CustomField.nameEquals(key, projectBuilder.getCustomReqFieldMap());
+
+			CustomFieldInfo customFieldInfo = getCustomFieldInfo(projectBuilder, docField, customResponseField,
+					customRequestField, isResp, simpleName);
+			// ignore custom field
+			if (Boolean.TRUE.equals(customFieldInfo.getIgnore())) {
+				continue;
+			}
+
+			// field json annotation
+			FieldJsonAnnotationInfo annotationInfo = getFieldJsonAnnotationInfo(projectBuilder, docField, isResp,
+					groupClasses, methodJsonViewClasses);
+			if (Boolean.TRUE.equals(annotationInfo.getIgnore())) {
+				continue;
+			}
+			// the param type from @JsonFormat
+			String fieldJsonFormatType = annotationInfo.getFieldJsonFormatType();
+			// the param value from @JsonFormat
+			String fieldJsonFormatValue = annotationInfo.getFieldJsonFormatValue();
+			// has Annotation @JsonSerialize And using ToStringSerializer
+			boolean toStringSerializer = Boolean.TRUE.equals(annotationInfo.getToStringSerializer());
+			if (Objects.nonNull(annotationInfo.getFieldName())) {
+				fieldName = annotationInfo.getFieldName();
+			}
+			if (Objects.nonNull(annotationInfo.getStrRequired())) {
+				strRequired = annotationInfo.getStrRequired();
+			}
+
+			comment.append(JavaFieldUtil.getJsrComment(projectBuilder.getApiConfig().isShowValidation(), classLoader,
+					javaAnnotations));
+			// fix mock post form curl example error
+			String fieldValue = getFieldValueFromMock(tagsMap);
+
+			if (StringUtil.isNotEmpty(customFieldInfo.getFieldValue())) {
+				fieldValue = customFieldInfo.getFieldValue();
+			}
+			if (StringUtil.isNotEmpty(customFieldInfo.getFieldName())) {
+				fieldName = customFieldInfo.getFieldName();
+			}
+			if (StringUtil.isNotEmpty(customFieldInfo.getComment())) {
+				comment = new StringBuilder(customFieldInfo.getComment());
+			}
+			if (Objects.nonNull(customFieldInfo.getStrRequired())) {
+				strRequired = customFieldInfo.getStrRequired();
+			}
+
+			fieldName = fieldName.trim();
+
+			int nextLevel = level + 1;
+			// Analyzing File Type Field
+			if (JavaClassValidateUtil.isFile(fieldGicName)) {
+				ApiParam param = ApiParam.of()
+					.setField(pre + fieldName)
+					.setType(ParamTypeConstants.PARAM_TYPE_FILE)
+					.setClassName(className)
+					.setPid(pid)
+					.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
+					.setMaxLength(maxLength)
+					.setDesc(comment.toString())
+					.setRequired(strRequired)
+					.setVersion(since)
+					.setExtensions(extensionParams);
+				if (fieldGicName.contains("[]") || fieldGicName.endsWith(">")) {
+					param.setType(ParamTypeConstants.PARAM_TYPE_FILE);
+					param.setDesc(comment.append("(array of file)").toString());
+					param.setHasItems(true);
+				}
+				paramList.add(param);
+				continue;
+			}
+			// Analyzing Map Type Field
+			if (JavaClassValidateUtil.isMap(subTypeName)) {
+				ApiParam param = ApiParam.of()
+					.setField(pre + fieldName)
+					.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
+					.setClassName(className)
+					.setPid(pid)
+					.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
+					.setMaxLength(maxLength)
+					.setDesc(comment.toString())
+					.setRequired(strRequired)
+					.setVersion(since)
+					.setExtensions(extensionParams);
+				paramList.add(param);
+
+				List<ApiParam> apiParams = buildMapParam(DocClassUtil.getSimpleGicName(fieldGicName),
+						DocUtil.getIndentByLevel(level), level + 1, isRequired, isResp, registryClasses, projectBuilder,
+						groupClasses, methodJsonViewClasses, param.getId(), jsonRequest, nextLevel, atomicInteger);
+				paramList.addAll(apiParams);
+				continue;
+			}
+			// Analyzing Primitive Type Field
+			if (JavaClassValidateUtil.isPrimitive(subTypeName)) {
+				if (StringUtil.isEmpty(fieldValue)) {
+					fieldValue = StringUtil.isNotEmpty(fieldJsonFormatValue) ? fieldJsonFormatValue
+							: StringUtil.removeQuotes(DocUtil.getValByTypeAndFieldName(subTypeName, field.getName()));
 				}
 
-				String fieldName = docField.getFieldName();
-				if (Objects.nonNull(fieldNameConvert)) {
-					fieldName = fieldNameConvert.translate(fieldName);
-				}
-				if (ignoreFields.containsKey(fieldName)) {
-					continue;
-				}
-
-				String subTypeName = docField.getTypeFullyQualifiedName();
-				boolean needToUnderline = (responseFieldToUnderline && isResp) || (requestFieldToUnderline && !isResp);
-				if (needToUnderline) {
-					fieldName = StringUtil.camelToUnderline(fieldName);
-				}
-				String typeSimpleName = field.getType().getSimpleName();
-				String fieldGicName = docField.getTypeGenericCanonicalName();
-				List<JavaAnnotation> javaAnnotations = docField.getAnnotations();
-
-				Map<String, String> tagsMap = DocUtil.getFieldTagsValue(field, docField);
-				// since tag value
-				String since = DocGlobalConstants.DEFAULT_VERSION;
-
-				if (tagsMap.containsKey(DocTags.SINCE)) {
-					since = tagsMap.get(DocTags.SINCE);
-				}
-				// handle extension
-				Map<String, String> extensions = DocUtil.getCommentsByTag(field.getTagsByName(DocTags.EXTENSION),
-						DocTags.EXTENSION);
-				Map<String, Object> extensionParams = new HashMap<>();
-				if (extensions != null && !extensions.isEmpty()) {
-					extensions.forEach((k, v) -> extensionParams.put(k, DocUtil.detectTagValue(v)));
-				}
-
-				boolean strRequired = false;
-				CustomField.Key key = CustomField.Key.create(docField.getDeclaringClassName(), fieldName);
-
-				CustomField customResponseField = CustomField.nameEquals(key, projectBuilder.getCustomRespFieldMap());
-				CustomField customRequestField = CustomField.nameEquals(key, projectBuilder.getCustomReqFieldMap());
-				if (customResponseField != null
-						&& JavaClassUtil.isTargetChildClass(docField.getDeclaringClassName(),
-								customResponseField.getOwnerClassName())
-						&& (customResponseField.isIgnore()) && isResp) {
-					continue;
-				}
-				if (customRequestField != null && JavaClassUtil.isTargetChildClass(docField.getDeclaringClassName(),
-						customRequestField.getOwnerClassName()) && (customRequestField.isIgnore()) && !isResp) {
-					continue;
-				}
-				// the param type from @JsonFormat
-				String fieldJsonFormatType = null;
-				// the param value from @JsonFormat
-				String fieldJsonFormatValue = null;
-				// has Annotation @JsonSerialize And using ToStringSerializer
-				boolean toStringSerializer = false;
-				// Handle @JsonView; if the field is not annotated with @JsonView, skip
-				// it.
-				if (!methodJsonViewClasses.isEmpty() && isResp && javaAnnotations.isEmpty()) {
-					continue;
-				}
-				for (JavaAnnotation annotation : javaAnnotations) {
-					// Handle @JsonView
-					if (JavaClassUtil.shouldExcludeFieldFromJsonView(annotation, methodJsonViewClasses, isResp,
-							projectBuilder)) {
-						continue out;
-					}
-
-					if (DocAnnotationConstants.SHORT_JSON_SERIALIZE.equals(annotation.getType().getSimpleName())
-							&& DocAnnotationConstants.TO_STRING_SERIALIZER_USING
-								.equals(annotation.getNamedParameter("using"))) {
-						toStringSerializer = true;
-						continue;
-					}
-					if (JavaClassValidateUtil.isIgnoreFieldJson(annotation, isResp)) {
-						continue out;
-					}
-
-					String simpleAnnotationName = annotation.getType().getValue();
-					if (DocAnnotationConstants.SHORT_JSON_FIELD.equals(simpleAnnotationName)) {
-						if (null != annotation.getProperty(DocAnnotationConstants.NAME_PROP)) {
-							fieldName = StringUtil
-								.removeQuotes(annotation.getProperty(DocAnnotationConstants.NAME_PROP).toString());
-						}
-					}
-					else {
-
-						if (DocAnnotationConstants.SHORT_JSON_PROPERTY.equals(simpleAnnotationName)
-								|| DocAnnotationConstants.GSON_ALIAS_NAME.equals(simpleAnnotationName)) {
-							AnnotationValue annotationValue = annotation.getProperty(DocAnnotationConstants.VALUE_PROP);
-							if (null != annotationValue) {
-								fieldName = StringUtil.removeQuotes(annotationValue.toString());
-							}
-						}
-						else if (JSRAnnotationConstants.NULL.equals(simpleAnnotationName) && !isResp) {
-							if (CollectionUtil.isEmpty(groupClasses)) {
-								continue out;
-							}
-							Set<String> groupClassList = JavaClassUtil.getParamGroupJavaClass(annotation);
-							for (String javaClass : groupClassList) {
-								if (groupClasses.contains(javaClass)) {
-									continue out;
-								}
-							}
-						}
-						else if (JavaClassValidateUtil.isJSR303Required(simpleAnnotationName) && !isResp) {
-							Set<String> groupClassList = JavaClassUtil.getParamGroupJavaClass(annotation);
-							// Check if groupClasses contains any element from
-							// groupClassList
-							boolean hasGroup = groupClassList.stream().anyMatch(groupClasses::contains);
-
-							if (hasGroup) {
-								strRequired = true;
-							}
-							else if (CollectionUtil.isEmpty(groupClasses)) {
-								// If the annotation is @Valid or @Validated, the Default
-								// group is added by default and groupClasses will not be
-								// empty;
-								// In other cases, if groupClasses is still empty, then
-								// strRequired is false.
-								strRequired = false;
-							}
-						}
-						else if (DocAnnotationConstants.JSON_FORMAT.equals(simpleAnnotationName)) {
-							fieldJsonFormatType = DocUtil.processFieldTypeNameByJsonFormat(isShowJavaType, subTypeName,
-									annotation);
-							fieldJsonFormatValue = DocUtil.getJsonFormatString(field, annotation);
-						}
-					}
-				}
-
-				comment.append(JavaFieldUtil.getJsrComment(apiConfig.isShowValidation(), classLoader, javaAnnotations));
-				// fix mock post form curl example error
-				String fieldValue = getFieldValueFromMock(tagsMap);
-
-				// cover response value
-				if (Objects.nonNull(customResponseField) && isResp && Objects.nonNull(customResponseField.getValue())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customResponseField.getOwnerClassName())) {
-					fieldValue = String.valueOf(customResponseField.getValue());
-				}
-				// cover request value
-				if (Objects.nonNull(customRequestField) && !isResp && Objects.nonNull(customRequestField.getValue())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customRequestField.getOwnerClassName())) {
-					fieldValue = String.valueOf(customRequestField.getValue());
-				}
-				// cover required
-				if (customRequestField != null && !isResp
-						&& JavaClassUtil.isTargetChildClass(simpleName, customRequestField.getOwnerClassName())
-						&& customRequestField.isRequire()) {
-					strRequired = true;
-				}
-				// cover comment
-				if (null != customRequestField && StringUtil.isNotEmpty(customRequestField.getDesc())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customRequestField.getOwnerClassName())
-						&& !isResp) {
-					comment = new StringBuilder(customRequestField.getDesc());
-				}
-				if (null != customResponseField && StringUtil.isNotEmpty(customResponseField.getDesc())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customResponseField.getOwnerClassName())
-						&& isResp) {
-					comment = new StringBuilder(customResponseField.getDesc());
-				}
-				// cover fieldName
-				if (null != customRequestField && StringUtil.isNotEmpty(customRequestField.getReplaceName())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customRequestField.getOwnerClassName())
-						&& !isResp) {
-					fieldName = customRequestField.getReplaceName();
-				}
-				if (null != customResponseField && StringUtil.isNotEmpty(customResponseField.getReplaceName())
-						&& JavaClassUtil.isTargetChildClass(simpleName, customResponseField.getOwnerClassName())
-						&& isResp) {
-					fieldName = customResponseField.getReplaceName();
-				}
-				fieldName = fieldName.trim();
-				// Analyzing File Type Field
-				if (JavaClassValidateUtil.isFile(fieldGicName)) {
-					ApiParam param = ApiParam.of()
-						.setField(pre + fieldName)
-						.setType(ParamTypeConstants.PARAM_TYPE_FILE)
-						.setClassName(className)
-						.setPid(pid)
-						.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
-						.setMaxLength(maxLength)
-						.setDesc(comment.toString())
-						.setRequired(strRequired)
-						.setVersion(since)
-						.setExtensions(extensionParams);
-					if (fieldGicName.contains("[]") || fieldGicName.endsWith(">")) {
-						param.setType(ParamTypeConstants.PARAM_TYPE_FILE);
-						param.setDesc(comment.append("(array of file)").toString());
-						param.setHasItems(true);
-					}
-					paramList.add(param);
-					continue;
-				}
-				// Analyzing Map Type Field
-				if (JavaClassValidateUtil.isMap(subTypeName)) {
-					ApiParam param = ApiParam.of()
-						.setField(pre + fieldName)
-						.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
-						.setClassName(className)
-						.setPid(pid)
-						.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
-						.setMaxLength(maxLength)
-						.setDesc(comment.toString())
-						.setRequired(strRequired)
-						.setVersion(since)
-						.setExtensions(extensionParams);
-					paramList.add(param);
-
-					List<ApiParam> apiParams = buildMapParam(DocClassUtil.getSimpleGicName(fieldGicName),
-							DocUtil.getIndentByLevel(level), level + 1, isRequired, isResp, registryClasses,
-							projectBuilder, groupClasses, methodJsonViewClasses, param.getId(), jsonRequest, nextLevel,
-							atomicInteger);
-					paramList.addAll(apiParams);
-					continue;
-				}
-
-				if (JavaClassValidateUtil.isPrimitive(subTypeName)) {
-					if (StringUtil.isEmpty(fieldValue)) {
-						fieldValue = StringUtil.isNotEmpty(fieldJsonFormatValue) ? fieldJsonFormatValue : StringUtil
-							.removeQuotes(DocUtil.getValByTypeAndFieldName(subTypeName, field.getName()));
-					}
-
-					ApiParam param = ApiParam.of()
-						.setClassName(className)
-						.setField(pre + fieldName)
-						.setPid(pid)
-						.setMaxLength(maxLength)
-						.setValue(fieldValue);
-					param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
-					String processedType = (isResp && toStringSerializer) ? "string"
-							: StringUtil.isNotEmpty(fieldJsonFormatType) ? fieldJsonFormatType
-									: processFieldTypeName(isShowJavaType, subTypeName);
-					param.setType(processedType);
-					param.setExtensions(extensionParams);
-					// handle param
-					commonHandleParam(paramList, param, isRequired, comment.toString(), since, strRequired);
-
-					JavaClass enumClass = ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap,
-							fieldJsonFormatValue);
-					if (Objects.nonNull(enumClass)) {
-						String enumClassComment = DocGlobalConstants.EMPTY;
-						if (StringUtil.isNotEmpty(enumClass.getComment())) {
-							enumClassComment = enumClass.getComment();
-						}
-						comment = new StringBuilder(
-								StringUtils.isEmpty(comment.toString()) ? enumClassComment : comment.toString());
-						String enumComment = handleEnumComment(enumClass, projectBuilder);
-						param.setDesc(comment + enumComment);
-					}
-				}
-				else {
-					String appendComment = "";
-					if (displayActualType) {
-						if (globGicName.length > 0) {
-							String gicName = genericMap.get(subTypeName) != null ? genericMap.get(subTypeName)
-									: globGicName[0];
-							if (!simpleName.equals(gicName)) {
-								appendComment = " (ActualType: " + JavaClassUtil.getClassSimpleName(gicName) + ")";
-							}
-						}
-						if (Objects.nonNull(docField.getActualJavaType())) {
-							appendComment = " (ActualType: "
-									+ JavaClassUtil.getClassSimpleName(docField.getActualJavaType()) + ")";
-						}
-					}
-
-					StringBuilder preBuilder = DocUtil.getStringBuilderByLevel(level);
-					int fieldPid;
-					ApiParam param = ApiParam.of()
-						.setField(pre + fieldName)
-						.setClassName(className)
-						.setPid(pid)
-						.setMaxLength(maxLength);
-					param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
-					param.setExtensions(extensionParams);
-					String processedType;
-					if (fieldGicName.length() == 1) {
-						String gicName = JavaTypeConstants.JAVA_OBJECT_FULLY;
-						if (Objects.nonNull(genericMap.get(typeSimpleName))) {
-							gicName = genericMap.get(subTypeName);
-						}
-						else {
-							if (globGicName.length > 0) {
-								gicName = globGicName[0];
-							}
-						}
-						if (JavaClassValidateUtil.isPrimitive(gicName)) {
-							processedType = DocClassUtil.processTypeNameForParams(gicName);
-						}
-						else {
-							processedType = DocClassUtil.processTypeNameForParams(typeSimpleName.toLowerCase());
-						}
-					}
-					else {
-						processedType = StringUtil.isNotEmpty(fieldJsonFormatType) ? fieldJsonFormatType
+				ApiParam param = ApiParam.of()
+					.setClassName(className)
+					.setField(pre + fieldName)
+					.setPid(pid)
+					.setMaxLength(maxLength)
+					.setValue(fieldValue);
+				param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
+				String processedType = (isResp && toStringSerializer) ? "string"
+						: StringUtil.isNotEmpty(fieldJsonFormatType) ? fieldJsonFormatType
 								: processFieldTypeName(isShowJavaType, subTypeName);
+				param.setType(processedType);
+				param.setExtensions(extensionParams);
+				// handle param
+				commonHandleParam(paramList, param, isRequired, comment.toString(), since, strRequired);
+
+				JavaClass enumClass = ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap,
+						fieldJsonFormatValue);
+				if (Objects.nonNull(enumClass)) {
+					String enumClassComment = DocGlobalConstants.EMPTY;
+					if (StringUtil.isNotEmpty(enumClass.getComment())) {
+						enumClassComment = enumClass.getComment();
 					}
-					param.setType(processedType);
-					JavaClass javaClass = field.getType();
-					if (javaClass.isEnum()) {
-						comment.append(handleEnumComment(javaClass, projectBuilder));
-						ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap,
-								fieldJsonFormatValue);
-						// hand Param
+					comment = new StringBuilder(
+							StringUtils.isEmpty(comment.toString()) ? enumClassComment : comment.toString());
+					String enumComment = handleEnumComment(enumClass, projectBuilder);
+					param.setDesc(comment + enumComment);
+				}
+			}
+			else {
+				String appendComment = "";
+				if (displayActualType) {
+					if (globGicName.length > 0) {
+						String gicName = genericMap.get(subTypeName) != null ? genericMap.get(subTypeName)
+								: globGicName[0];
+						if (!simpleName.equals(gicName)) {
+							appendComment = " (ActualType: " + JavaClassUtil.getClassSimpleName(gicName) + ")";
+						}
+					}
+					if (Objects.nonNull(docField.getActualJavaType())) {
+						appendComment = " (ActualType: "
+								+ JavaClassUtil.getClassSimpleName(docField.getActualJavaType()) + ")";
+					}
+				}
+
+				StringBuilder preBuilder = DocUtil.getStringBuilderByLevel(level);
+				int fieldPid;
+				ApiParam param = ApiParam.of()
+					.setField(pre + fieldName)
+					.setClassName(className)
+					.setPid(pid)
+					.setMaxLength(maxLength);
+				param.setId(atomicOrDefault(atomicInteger, paramList.size() + param.getPid() + 1));
+				param.setExtensions(extensionParams);
+				String processedType;
+				if (fieldGicName.length() == 1) {
+					String gicName = JavaTypeConstants.JAVA_OBJECT_FULLY;
+					if (Objects.nonNull(genericMap.get(typeSimpleName))) {
+						gicName = genericMap.get(subTypeName);
+					}
+					else {
+						if (globGicName.length > 0) {
+							gicName = globGicName[0];
+						}
+					}
+					if (JavaClassValidateUtil.isPrimitive(gicName)) {
+						processedType = DocClassUtil.processTypeNameForParams(gicName);
+					}
+					else {
+						processedType = DocClassUtil.processTypeNameForParams(typeSimpleName.toLowerCase());
+					}
+				}
+				else {
+					processedType = StringUtil.isNotEmpty(fieldJsonFormatType) ? fieldJsonFormatType
+							: processFieldTypeName(isShowJavaType, subTypeName);
+				}
+				param.setType(processedType);
+				JavaClass javaClass = field.getType();
+				if (javaClass.isEnum()) {
+					comment.append(handleEnumComment(javaClass, projectBuilder));
+					ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap, fieldJsonFormatValue);
+					// hand Param
+					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
+				}
+				else if (JavaClassValidateUtil.isCollection(subTypeName)
+						|| JavaClassValidateUtil.isArray(subTypeName)) {
+					if (isShowJavaType) {
+						// rpc
+						param.setType(
+								JavaFieldUtil.convertToSimpleTypeName(docField.getTypeGenericFullyQualifiedName()));
+					}
+					else {
+						param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
+					}
+					if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
+						param.setValue(fieldValue);
+					}
+					if (globGicName.length > 0 && JavaTypeConstants.JAVA_LIST_FULLY.equals(fieldGicName)) {
+						// no generic, just object
+						fieldGicName = fieldGicName + "<T>";
+					}
+					if (JavaClassValidateUtil.isArray(subTypeName)) {
+						fieldGicName = fieldGicName.substring(0, fieldGicName.lastIndexOf("["));
+						fieldGicName = "java.util.List<" + fieldGicName + ">";
+					}
+					String[] gNameArr = DocClassUtil.getSimpleGicName(fieldGicName);
+					if (gNameArr.length == 0) {
+						continue;
+					}
+					else {
+						String gName = DocClassUtil.getSimpleGicName(fieldGicName)[0];
+						JavaClass javaClass1 = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
+						comment.append(handleEnumComment(javaClass1, projectBuilder));
+					}
+					String gName = gNameArr[0];
+					if (JavaClassValidateUtil.isPrimitive(gName)) {
+						String builder = DocUtil.jsonValueByType(gName) + "," + DocUtil.jsonValueByType(gName);
+
+						if (StringUtil.isEmpty(fieldValue)) {
+							param.setValue(DocUtil.handleJsonStr(builder));
+						}
+						else {
+							param.setValue(fieldValue);
+						}
 						commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
 					}
-					else if (JavaClassValidateUtil.isCollection(subTypeName)
-							|| JavaClassValidateUtil.isArray(subTypeName)) {
-						if (isShowJavaType) {
-							// rpc
-							param.setType(
-									JavaFieldUtil.convertToSimpleTypeName(docField.getTypeGenericFullyQualifiedName()));
-						}
-						else {
-							param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
-						}
-						if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
-							param.setValue(fieldValue);
-						}
-						if (globGicName.length > 0 && "java.util.List".equals(fieldGicName)) {
-							// no generic, just object
-							fieldGicName = fieldGicName + "<T>";
-						}
-						if (JavaClassValidateUtil.isArray(subTypeName)) {
-							fieldGicName = fieldGicName.substring(0, fieldGicName.lastIndexOf("["));
-							fieldGicName = "java.util.List<" + fieldGicName + ">";
-						}
-						String[] gNameArr = DocClassUtil.getSimpleGicName(fieldGicName);
-						if (gNameArr.length == 0) {
-							continue;
-						}
-						if (gNameArr.length > 0) {
-							String gName = DocClassUtil.getSimpleGicName(fieldGicName)[0];
-							JavaClass javaClass1 = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
-							comment.append(handleEnumComment(javaClass1, projectBuilder));
-						}
-						String gName = gNameArr[0];
-						if (JavaClassValidateUtil.isPrimitive(gName)) {
-							String builder = DocUtil.jsonValueByType(gName) + "," + DocUtil.jsonValueByType(gName);
-
-							if (StringUtil.isEmpty(fieldValue)) {
-								param.setValue(DocUtil.handleJsonStr(builder));
-							}
-							else {
-								param.setValue(fieldValue);
-							}
-							commonHandleParam(paramList, param, isRequired, comment + appendComment, since,
-									strRequired);
-						}
-						else {
-							commonHandleParam(paramList, param, isRequired, comment + appendComment, since,
-									strRequired);
-							fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId()
-									: paramList.size() + pid;
-							if (!simpleName.equals(gName)) {
-								JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
-								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder,
-											Boolean.FALSE);
-									param.setValue("[\"" + value + "\"]")
-										.setEnumInfo(JavaClassUtil.getEnumInfo(arraySubClass, projectBuilder))
-										.setEnumValues(JavaClassUtil.getEnumValues(arraySubClass));
-								}
-								else if (gName.length() == 1) {
-									// handle generic
-									int len = globGicName.length;
-									if (len < 1) {
-										continue;
-									}
-									String gicName = genericMap.get(gName) != null ? genericMap.get(gName)
-											: globGicName[0];
-
-									if (!JavaClassValidateUtil.isPrimitive(gicName) && !simpleName.equals(gicName)) {
-										paramList.addAll(buildParams(gicName, preBuilder.toString(), nextLevel,
-												isRequired, isResp, registryClasses, projectBuilder, groupClasses,
-												methodJsonViewClasses, fieldPid, jsonRequest, atomicInteger));
-									}
-								}
-								else {
-									paramList.addAll(buildParams(gName, preBuilder.toString(), nextLevel, isRequired,
-											isResp, registryClasses, projectBuilder, groupClasses,
-											methodJsonViewClasses, fieldPid, jsonRequest, atomicInteger));
-								}
-							}
-							else {
-								param.setSelfReferenceLoop(true);
-							}
-						}
-
-					}
-					else if (JavaClassValidateUtil.isMap(subTypeName)) {
-						if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
-							param.setType(ParamTypeConstants.PARAM_TYPE_MAP);
-							param.setValue(fieldValue);
-						}
+					else {
 						commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
 						fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId()
 								: paramList.size() + pid;
-						String valType = DocClassUtil.getMapKeyValueType(fieldGicName).length == 0 ? fieldGicName
-								: DocClassUtil.getMapKeyValueType(fieldGicName)[1];
-						if (JavaClassValidateUtil.isMap(fieldGicName)
-								|| JavaTypeConstants.JAVA_OBJECT_FULLY.equals(valType)) {
-							ApiParam param1 = ApiParam.of()
-								.setField(preBuilder.toString() + "any object")
-								.setId(atomicOrDefault(atomicInteger, fieldPid + 1))
-								.setPid(fieldPid)
-								.setClassName(className)
-								.setMaxLength(maxLength)
-								.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
-								.setDesc(DocGlobalConstants.ANY_OBJECT_MSG)
-								.setVersion(DocGlobalConstants.DEFAULT_VERSION)
-								.setExtensions(extensionParams);
-							paramList.add(param1);
-							continue;
-						}
-						if (!JavaClassValidateUtil.isPrimitive(valType)) {
-							if (valType.length() == 1) {
-								String gicName = genericMap.get(valType);
+						if (!simpleName.equals(gName)) {
+							JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
+							if (arraySubClass.isEnum()) {
+								Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder, Boolean.FALSE);
+								param.setValue("[\"" + value + "\"]")
+									.setEnumInfo(JavaClassUtil.getEnumInfo(arraySubClass, projectBuilder))
+									.setEnumValues(JavaClassUtil.getEnumValues(arraySubClass));
+							}
+							else if (gName.length() == 1) {
+								// handle generic
+								int len = globGicName.length;
+								if (len < 1) {
+									continue;
+								}
+								String gicName = genericMap.get(gName) != null ? genericMap.get(gName) : globGicName[0];
+
 								if (!JavaClassValidateUtil.isPrimitive(gicName) && !simpleName.equals(gicName)) {
 									paramList.addAll(buildParams(gicName, preBuilder.toString(), nextLevel, isRequired,
 											isResp, registryClasses, projectBuilder, groupClasses,
@@ -609,47 +504,85 @@ public class ParamsBuildHelper extends BaseHelper {
 								}
 							}
 							else {
-								paramList.addAll(buildParams(valType, preBuilder.toString(), nextLevel, isRequired,
+								paramList.addAll(buildParams(gName, preBuilder.toString(), nextLevel, isRequired,
 										isResp, registryClasses, projectBuilder, groupClasses, methodJsonViewClasses,
 										fieldPid, jsonRequest, atomicInteger));
 							}
 						}
-					}
-					else if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(fieldGicName)) {
-						if (StringUtil.isEmpty(param.getDesc())) {
-							param.setDesc(DocGlobalConstants.ANY_OBJECT_MSG);
+						else {
+							param.setSelfReferenceLoop(true);
 						}
-						commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
 					}
-					else if (fieldGicName.length() == 1) {
-						commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
-						fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId()
-								: paramList.size() + pid;
-						// handle java generic or object
-						if (!simpleName.equals(className)) {
-							if (globGicName.length > 0) {
-								String gicName = genericMap.get(subTypeName) != null ? genericMap.get(subTypeName)
-										: globGicName[0];
-								String simple = DocClassUtil.getSimpleName(gicName);
-								// set type array
-								if (JavaClassValidateUtil.isArray(gicName)) {
+
+				}
+				else if (JavaClassValidateUtil.isMap(subTypeName)) {
+					if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
+						param.setType(ParamTypeConstants.PARAM_TYPE_MAP);
+						param.setValue(fieldValue);
+					}
+					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
+					fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId() : paramList.size() + pid;
+					String valType = DocClassUtil.getMapKeyValueType(fieldGicName).length == 0 ? fieldGicName
+							: DocClassUtil.getMapKeyValueType(fieldGicName)[1];
+					if (JavaClassValidateUtil.isMap(fieldGicName)
+							|| JavaTypeConstants.JAVA_OBJECT_FULLY.equals(valType)) {
+						ApiParam param1 = ApiParam.of()
+							.setField(preBuilder + "any object")
+							.setId(atomicOrDefault(atomicInteger, fieldPid + 1))
+							.setPid(fieldPid)
+							.setClassName(className)
+							.setMaxLength(maxLength)
+							.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
+							.setDesc(DocGlobalConstants.ANY_OBJECT_MSG)
+							.setVersion(DocGlobalConstants.DEFAULT_VERSION)
+							.setExtensions(extensionParams);
+						paramList.add(param1);
+						continue;
+					}
+					if (!JavaClassValidateUtil.isPrimitive(valType)) {
+						if (valType.length() == 1) {
+							String gicName = genericMap.get(valType);
+							if (!JavaClassValidateUtil.isPrimitive(gicName) && !simpleName.equals(gicName)) {
+								paramList.addAll(buildParams(gicName, preBuilder.toString(), nextLevel, isRequired,
+										isResp, registryClasses, projectBuilder, groupClasses, methodJsonViewClasses,
+										fieldPid, jsonRequest, atomicInteger));
+							}
+						}
+						else {
+							paramList.addAll(buildParams(valType, preBuilder.toString(), nextLevel, isRequired, isResp,
+									registryClasses, projectBuilder, groupClasses, methodJsonViewClasses, fieldPid,
+									jsonRequest, atomicInteger));
+						}
+					}
+				}
+				else if (JavaTypeConstants.JAVA_OBJECT_FULLY.equals(fieldGicName)) {
+					if (StringUtil.isEmpty(param.getDesc())) {
+						param.setDesc(DocGlobalConstants.ANY_OBJECT_MSG);
+					}
+					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
+				}
+				else if (fieldGicName.length() == 1) {
+					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
+					fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId() : paramList.size() + pid;
+					// handle java generic or object
+					if (!simpleName.equals(className)) {
+						if (globGicName.length > 0) {
+							String gicName = genericMap.get(subTypeName) != null ? genericMap.get(subTypeName)
+									: globGicName[0];
+							String simple = DocClassUtil.getSimpleName(gicName);
+							// set type array
+							if (JavaClassValidateUtil.isArray(gicName)) {
+								param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
+							}
+							if (JavaClassValidateUtil.isPrimitive(simple)) {
+								// do nothing
+							}
+							else if (gicName.contains("<")) {
+								if (JavaClassValidateUtil.isCollection(simple)) {
 									param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
-								}
-								if (JavaClassValidateUtil.isPrimitive(simple)) {
-									// do nothing
-								}
-								else if (gicName.contains("<")) {
-									if (JavaClassValidateUtil.isCollection(simple)) {
-										param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
-										String gName = DocClassUtil.getSimpleGicName(gicName)[0];
-										if (!JavaClassValidateUtil.isPrimitive(gName)) {
-											paramList.addAll(buildParams(gName, preBuilder.toString(), nextLevel,
-													isRequired, isResp, registryClasses, projectBuilder, groupClasses,
-													methodJsonViewClasses, fieldPid, jsonRequest, atomicInteger));
-										}
-									}
-									else {
-										paramList.addAll(buildParams(gicName, preBuilder.toString(), nextLevel,
+									String gName = DocClassUtil.getSimpleGicName(gicName)[0];
+									if (!JavaClassValidateUtil.isPrimitive(gName)) {
+										paramList.addAll(buildParams(gName, preBuilder.toString(), nextLevel,
 												isRequired, isResp, registryClasses, projectBuilder, groupClasses,
 												methodJsonViewClasses, fieldPid, jsonRequest, atomicInteger));
 									}
@@ -661,40 +594,46 @@ public class ParamsBuildHelper extends BaseHelper {
 								}
 							}
 							else {
-								paramList.addAll(buildParams(subTypeName, preBuilder.toString(), nextLevel, isRequired,
+								paramList.addAll(buildParams(gicName, preBuilder.toString(), nextLevel, isRequired,
 										isResp, registryClasses, projectBuilder, groupClasses, methodJsonViewClasses,
 										fieldPid, jsonRequest, atomicInteger));
 							}
 						}
-					}
-					else if (simpleName.equals(subTypeName)) {
-						// reference self
-						ApiParam param1 = ApiParam.of()
-							.setField(pre + fieldName)
-							.setPid(pid)
-							.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
-							.setClassName(subTypeName)
-							.setMaxLength(maxLength)
-							.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
-							.setDesc(comment.append(" $ref... self").toString())
-							.setVersion(DocGlobalConstants.DEFAULT_VERSION)
-							.setExtensions(extensionParams);
-						paramList.add(param1);
-					}
-					else {
-						commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
-						fieldGicName = DocUtil.formatFieldTypeGicName(genericMap, fieldGicName);
-						fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId()
-								: paramList.size() + pid;
-						paramList.addAll(buildParams(fieldGicName, preBuilder.toString(), nextLevel, isRequired, isResp,
-								registryClasses, projectBuilder, groupClasses, methodJsonViewClasses, fieldPid,
-								jsonRequest, atomicInteger));
-
+						else {
+							paramList.addAll(buildParams(subTypeName, preBuilder.toString(), nextLevel, isRequired,
+									isResp, registryClasses, projectBuilder, groupClasses, methodJsonViewClasses,
+									fieldPid, jsonRequest, atomicInteger));
+						}
 					}
 				}
-			} // end field
+				else if (simpleName.equals(subTypeName)) {
+					// reference self
+					ApiParam param1 = ApiParam.of()
+						.setField(pre + fieldName)
+						.setPid(pid)
+						.setId(atomicOrDefault(atomicInteger, paramList.size() + pid + 1))
+						.setClassName(subTypeName)
+						.setMaxLength(maxLength)
+						.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
+						.setDesc(comment.append(" $ref... self").toString())
+						.setVersion(DocGlobalConstants.DEFAULT_VERSION)
+						.setExtensions(extensionParams);
+					paramList.add(param1);
+				}
+				else {
+					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
+					fieldGicName = DocUtil.formatFieldTypeGicName(genericMap, fieldGicName);
+					fieldPid = Optional.ofNullable(atomicInteger).isPresent() ? param.getId() : paramList.size() + pid;
+					paramList.addAll(buildParams(fieldGicName, preBuilder.toString(), nextLevel, isRequired, isResp,
+							registryClasses, projectBuilder, groupClasses, methodJsonViewClasses, fieldPid, jsonRequest,
+							atomicInteger));
+
+				}
+			}
+
 		}
 		return paramList;
+		// end field
 	}
 
 	/**
@@ -714,7 +653,7 @@ public class ParamsBuildHelper extends BaseHelper {
 	 * @param atomicInteger the atomic integer for generating unique IDs
 	 * @return a list of {@link ApiParam} objects
 	 */
-	private static List<ApiParam> buildMapParam(String[] globGicName, String pre, int level, String isRequired,
+	public static List<ApiParam> buildMapParam(String[] globGicName, String pre, int level, String isRequired,
 			boolean isResp, Map<String, String> registryClasses, ProjectDocConfigBuilder projectBuilder,
 			Set<String> groupClasses, Set<String> jsonViewClasses, int pid, boolean jsonRequest, int nextLevel,
 			AtomicInteger atomicInteger) {
@@ -805,7 +744,7 @@ public class ParamsBuildHelper extends BaseHelper {
 		if (JavaClassValidateUtil.isPrimitive(valueSimpleName)) {
 			return Collections.emptyList();
 		}
-		return buildParams(globGicName[1], DocUtil.getIndentByLevel(level), ++nextLevel, isRequired, isResp,
+		return buildParams(globGicName[1], DocUtil.getIndentByLevel(level), nextLevel, isRequired, isResp,
 				registryClasses, projectBuilder, groupClasses, jsonViewClasses, pid, jsonRequest, atomicInteger);
 	}
 
@@ -880,6 +819,13 @@ public class ParamsBuildHelper extends BaseHelper {
 		return comment;
 	}
 
+	/**
+	 * Returns the next value of the specified atomic integer or the default value if the
+	 * atomic integer is null.
+	 * @param atomicInteger the atomic integer
+	 * @param defaultVal the default value
+	 * @return the next value of the atomic integer or the default value
+	 */
 	private static int atomicOrDefault(AtomicInteger atomicInteger, int defaultVal) {
 		if (null != atomicInteger) {
 			return atomicInteger.incrementAndGet();
@@ -887,6 +833,12 @@ public class ParamsBuildHelper extends BaseHelper {
 		return defaultVal;
 	}
 
+	/**
+	 * Processes the field type name based on the specified flag.
+	 * @param isShowJavaType a flag indicating whether to show the Java type or not
+	 * @param fieldTypeName the field type name to be processed
+	 * @return the processed field type name
+	 */
 	private static String processFieldTypeName(boolean isShowJavaType, String fieldTypeName) {
 		if (isShowJavaType) {
 			return JavaFieldUtil.convertToSimpleTypeName(fieldTypeName);
@@ -894,6 +846,96 @@ public class ParamsBuildHelper extends BaseHelper {
 		else {
 			return DocClassUtil.processTypeNameForParams(fieldTypeName.toLowerCase());
 		}
+	}
+
+	/**
+	 * Handles primitive types and returns a list of {@link ApiParam} objects.
+	 * @param simpleName the simple name of the primitive type
+	 * @param isShowJavaType a flag indicating whether to show the Java type or not
+	 * @param atomicInteger the atomic integer for generating unique IDs
+	 * @param pid the parent ID
+	 * @return the list of {@link ApiParam} objects
+	 */
+	private static List<ApiParam> handlePrimitiveType(String simpleName, boolean isShowJavaType,
+			AtomicInteger atomicInteger, int pid) {
+		String processedType = processFieldTypeName(isShowJavaType, simpleName);
+		return primitiveReturnRespComment(processedType, atomicInteger, pid);
+	}
+
+	/**
+	 * Builds a list of {@link ApiParam} objects for a map type.
+	 * @param globGicName the generic canonical name of the map type
+	 * @param pre the prefix for the field name
+	 * @param level the level of the parameter
+	 * @param isRequired the required flag for the parameter
+	 * @param isResp the response flag for the parameter
+	 * @param registryClasses the registry classes
+	 * @param projectBuilder the project builder
+	 * @param groupClasses the group classes
+	 * @param methodJsonViewClasses the method JSON view classes
+	 * @param pid the parent ID
+	 * @param jsonRequest the request flag for the parameter
+	 * @param atomicInteger the atomic integer for generating unique IDs
+	 * @param simpleName the simple name of the collection type
+	 *
+	 */
+	private static List<ApiParam> handleCollectionOrArrayType(String[] globGicName, String pre, int level,
+			String isRequired, boolean isResp, Map<String, String> registryClasses,
+			ProjectDocConfigBuilder projectBuilder, Set<String> groupClasses, Set<String> methodJsonViewClasses,
+			int pid, boolean jsonRequest, AtomicInteger atomicInteger, String simpleName) {
+		List<ApiParam> paramList = new ArrayList<>();
+		if (!JavaClassValidateUtil.isCollection(globGicName[0])) {
+			String gNameTemp = globGicName[0];
+			String gName = JavaClassValidateUtil.isArray(gNameTemp) ? gNameTemp.substring(0, gNameTemp.indexOf("["))
+					: globGicName[0];
+			if (JavaClassValidateUtil.isPrimitive(gName)) {
+				String processedType = projectBuilder.getApiConfig().getShowJavaType()
+						? JavaFieldUtil.convertToSimpleTypeName(simpleName)
+						: DocClassUtil.processTypeNameForParams(gName);
+				ApiParam param = ApiParam.of()
+					.setId(atomicOrDefault(atomicInteger, pid + 1))
+					.setField(pre + " -")
+					.setType("array[" + processedType + "]")
+					.setPid(pid)
+					.setDesc("array of " + processedType)
+					.setVersion(DocGlobalConstants.DEFAULT_VERSION)
+					.setRequired(Boolean.parseBoolean(isRequired));
+				paramList.add(param);
+			}
+			else {
+				if (JavaClassValidateUtil.isArray(gNameTemp)) {
+					gNameTemp = gNameTemp.substring(0, gNameTemp.indexOf("["));
+				}
+				paramList.addAll(buildParams(gNameTemp, pre, level + 1, isRequired, isResp, registryClasses,
+						projectBuilder, groupClasses, methodJsonViewClasses, pid, jsonRequest, atomicInteger));
+			}
+		}
+		return paramList;
+	}
+
+	/**
+	 * Builds a list of {@link ApiParam} objects for a generic object type.
+	 * @param className the canonical name of the generic object type
+	 * @param pre the prefix for the field name
+	 * @param isRequired the required flag for the parameter
+	 * @param atomicInteger the atomic integer for generating unique IDs
+	 * @param pid the parent ID
+	 * @return the list of {@link ApiParam} objects
+	 */
+	private static List<ApiParam> buildGenericObjectParam(String className, String pre, String isRequired,
+			AtomicInteger atomicInteger, int pid) {
+		List<ApiParam> paramList = new ArrayList<>();
+		ApiParam apiParam = ApiParam.of()
+			.setClassName(className)
+			.setId(atomicOrDefault(atomicInteger, pid + 1))
+			.setField(pre + "any object")
+			.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
+			.setPid(pid)
+			.setDesc(DocGlobalConstants.ANY_OBJECT_MSG)
+			.setVersion(DocGlobalConstants.DEFAULT_VERSION)
+			.setRequired(Boolean.parseBoolean(isRequired));
+		paramList.add(apiParam);
+		return paramList;
 	}
 
 }

--- a/src/main/java/com/ly/doc/model/CustomField.java
+++ b/src/main/java/com/ly/doc/model/CustomField.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ * Custom field
+ *
  * @author xingzi
  **/
 public class CustomField {
@@ -53,14 +55,30 @@ public class CustomField {
 	 */
 	private boolean require;
 
+	/**
+	 * ignore
+	 */
 	private boolean ignore;
 
+	/**
+	 * replace name
+	 */
 	private String replaceName;
 
+	/**
+	 * Builder
+	 * @return CustomField
+	 */
 	public static CustomField builder() {
 		return new CustomField();
 	}
 
+	/**
+	 * get custom field by key
+	 * @param key key
+	 * @param customFieldMap custom field map
+	 * @return CustomField
+	 */
 	public static CustomField nameEquals(Key key, Map<Key, CustomField> customFieldMap) {
 		for (Map.Entry<Key, CustomField> c : customFieldMap.entrySet()) {
 			if (key.equals(c.getKey())) {

--- a/src/main/java/com/ly/doc/model/CustomFieldInfo.java
+++ b/src/main/java/com/ly/doc/model/CustomFieldInfo.java
@@ -1,0 +1,88 @@
+package com.ly.doc.model;
+
+import java.io.Serializable;
+
+/**
+ * CustomFieldInfo
+ *
+ * @author linwumingshi
+ * @since 3.0.9
+ */
+public class CustomFieldInfo implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = -7310122325722122250L;
+
+	/**
+	 * ignore
+	 */
+	private Boolean ignore;
+
+	/**
+	 * field name
+	 */
+	private String fieldName;
+
+	/**
+	 * field value
+	 */
+	private String fieldValue;
+
+	/**
+	 * is required
+	 */
+	private Boolean strRequired;
+
+	/**
+	 * comment
+	 */
+	private String comment;
+
+	public Boolean getIgnore() {
+		return ignore;
+	}
+
+	public CustomFieldInfo setIgnore(Boolean ignore) {
+		this.ignore = ignore;
+		return this;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public CustomFieldInfo setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+		return this;
+	}
+
+	public String getFieldValue() {
+		return fieldValue;
+	}
+
+	public CustomFieldInfo setFieldValue(String fieldValue) {
+		this.fieldValue = fieldValue;
+		return this;
+	}
+
+	public Boolean getStrRequired() {
+		return strRequired;
+	}
+
+	public CustomFieldInfo setStrRequired(Boolean strRequired) {
+		this.strRequired = strRequired;
+		return this;
+	}
+
+	public String getComment() {
+		return comment;
+	}
+
+	public CustomFieldInfo setComment(String comment) {
+		this.comment = comment;
+		return this;
+	}
+
+}

--- a/src/main/java/com/ly/doc/model/DocJavaField.java
+++ b/src/main/java/com/ly/doc/model/DocJavaField.java
@@ -20,14 +20,16 @@
  */
 package com.ly.doc.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.thoughtworks.qdox.model.DocletTag;
 import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaField;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
+ * The doc of java field
+ *
  * @author yu 2020/3/19.
  */
 public class DocJavaField {

--- a/src/main/java/com/ly/doc/model/FieldJsonAnnotationInfo.java
+++ b/src/main/java/com/ly/doc/model/FieldJsonAnnotationInfo.java
@@ -1,0 +1,102 @@
+package com.ly.doc.model;
+
+import java.io.Serializable;
+
+/**
+ * FieldJsonAnnotationInfo
+ *
+ * @author linwumingshi
+ * @since 3.0.9
+ */
+public class FieldJsonAnnotationInfo implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = 9003861567366363140L;
+
+	/**
+	 * the param type from @JsonFormat
+	 */
+	private String fieldJsonFormatType;
+
+	/**
+	 * the param value from @JsonFormat
+	 */
+	private String fieldJsonFormatValue;
+
+	/**
+	 * has Annotation @JsonSerialize And using ToStringSerializer
+	 */
+	private Boolean toStringSerializer;
+
+	/**
+	 * is required
+	 */
+	private Boolean strRequired;
+
+	/**
+	 * field name
+	 */
+	private String fieldName;
+
+	/**
+	 * is ignored
+	 */
+	private Boolean isIgnore;
+
+	public String getFieldJsonFormatType() {
+		return fieldJsonFormatType;
+	}
+
+	public FieldJsonAnnotationInfo setFieldJsonFormatType(String fieldJsonFormatType) {
+		this.fieldJsonFormatType = fieldJsonFormatType;
+		return this;
+	}
+
+	public String getFieldJsonFormatValue() {
+		return fieldJsonFormatValue;
+	}
+
+	public FieldJsonAnnotationInfo setFieldJsonFormatValue(String fieldJsonFormatValue) {
+		this.fieldJsonFormatValue = fieldJsonFormatValue;
+		return this;
+	}
+
+	public Boolean getToStringSerializer() {
+		return toStringSerializer;
+	}
+
+	public FieldJsonAnnotationInfo setToStringSerializer(Boolean toStringSerializer) {
+		this.toStringSerializer = toStringSerializer;
+		return this;
+	}
+
+	public Boolean getStrRequired() {
+		return strRequired;
+	}
+
+	public FieldJsonAnnotationInfo setStrRequired(Boolean strRequired) {
+		this.strRequired = strRequired;
+		return this;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public FieldJsonAnnotationInfo setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+		return this;
+	}
+
+	public Boolean getIgnore() {
+		return isIgnore;
+	}
+
+	public FieldJsonAnnotationInfo setIgnore(Boolean ignore) {
+		isIgnore = ignore;
+		return this;
+	}
+
+}

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -106,7 +106,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 			// from tag
 			DocletTag ignoreTag = cls.getTagByName(DocTags.IGNORE);
-			if (!isEntryPoint(cls, frameworkAnnotations) || Objects.nonNull(ignoreTag)) {
+			if (!this.isEntryPoint(cls, frameworkAnnotations) || Objects.nonNull(ignoreTag)) {
 				continue;
 			}
 			int order = 0;
@@ -583,10 +583,10 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				if (Objects.nonNull(method.getTagByName(IGNORE))) {
 					continue;
 				}
-				docJavaMethods.add(convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
+				docJavaMethods.add(this.convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
 			}
 			// add parent class methods
-			docJavaMethods.addAll(getParentsClassMethods(apiConfig, projectBuilder, cls));
+			docJavaMethods.addAll(this.getParentsClassMethods(apiConfig, projectBuilder, cls));
 
 			for (DocJavaMethod docJavaMethod : docJavaMethods) {
 				JavaMethod method = docJavaMethod.getJavaMethod();
@@ -607,7 +607,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				apiExceptionStatus.setDetail(docJavaMethod.getDetail());
 
 				// build response params
-				List<ApiParam> responseParams = buildReturnApiParams(docJavaMethod, projectBuilder);
+				List<ApiParam> responseParams = this.buildReturnApiParams(docJavaMethod, projectBuilder);
 				if (paramsDataToTree) {
 					responseParams = ApiParamTreeUtil.apiParamToTree(responseParams);
 				}
@@ -626,7 +626,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 		}
 		if (apiConfig.isAddDefaultHttpStatuses() && exceptionStatusList.isEmpty()) {
-			exceptionStatusList.addAll(defaultHttpErrorStatuses());
+			exceptionStatusList.addAll(this.defaultHttpErrorStatuses());
 		}
 		Collections.sort(exceptionStatusList);
 		return exceptionStatusList;
@@ -654,7 +654,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			ProjectDocConfigBuilder projectBuilder, FrameworkAnnotations frameworkAnnotations,
 			List<ApiReqParam> configApiReqParams, IRequestMappingHandler baseMappingHandler,
 			IHeaderHandler headerHandler) {
-		String clazName = cls.getCanonicalName();
+		String clazzName = cls.getCanonicalName();
 		boolean paramsDataToTree = projectBuilder.getApiConfig().isParamsDataToTree();
 		ClassLoader classLoader = projectBuilder.getApiConfig().getClassLoader();
 		String group = JavaClassUtil.getClassTagsValue(cls, DocTags.GROUP, Boolean.TRUE);
@@ -687,14 +687,14 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 		}
 
-		Set<String> filterMethods = DocUtil.findFilterMethods(clazName);
+		Set<String> filterMethods = DocUtil.findFilterMethods(clazzName);
 		boolean needAllMethods = filterMethods.contains(DocGlobalConstants.DEFAULT_FILTER_METHOD);
 
 		List<JavaMethod> methods = cls.getMethods();
 		List<DocJavaMethod> docJavaMethods = new ArrayList<>(methods.size());
 		for (JavaMethod method : methods) {
 			if (method.isPrivate()
-					|| DocUtil.isMatch(apiConfig.getPackageExcludeFilters(), clazName + "." + method.getName())) {
+					|| DocUtil.isMatch(apiConfig.getPackageExcludeFilters(), clazzName + "." + method.getName())) {
 				continue;
 			}
 			if (Objects.nonNull(method.getTagByName(IGNORE))) {
@@ -705,7 +705,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 		}
 		// add parent class methods
-		docJavaMethods.addAll(getParentsClassMethods(apiConfig, projectBuilder, cls));
+		docJavaMethods.addAll(this.getParentsClassMethods(apiConfig, projectBuilder, cls));
 		List<JavaType> implClasses = cls.getImplements();
 		for (JavaType type : implClasses) {
 			JavaClass javaClass = (JavaClass) type;
@@ -769,7 +769,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			apiMethodDoc.setDesc(common);
 			apiMethodDoc.setAuthor(docJavaMethod.getAuthor());
 			apiMethodDoc.setDetail(docJavaMethod.getDetail());
-			String methodUid = DocUtil.generateId(clazName + method.getName() + methodOrder);
+			String methodUid = DocUtil.generateId(clazzName + method.getName() + methodOrder);
 			apiMethodDoc.setMethodId(methodUid);
 			// handle headers
 			List<ApiReqParam> apiReqHeaders = headerHandler.handle(method, projectBuilder);
@@ -897,13 +897,13 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				}
 				String params = StringUtil.removeQuotes(paramsObjects.toString());
 				if (!params.startsWith("[")) {
-					mappingParamToApiParam(paramsObjects.toString(), paramList, mappingParams);
+					this.mappingParamToApiParam(paramsObjects.toString(), paramList, mappingParams);
 					continue;
 				}
 				@SuppressWarnings("unchecked")
 				List<String> headers = (LinkedList<String>) paramsObjects;
 				for (String str : headers) {
-					mappingParamToApiParam(str, paramList, mappingParams);
+					this.mappingParamToApiParam(str, paramList, mappingParams);
 				}
 			}
 		}
@@ -914,7 +914,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				Collections.emptyMap());
 		final Map<String, ApiReqParam> queryReqParamMap = collect.getOrDefault(ApiReqParamInTypeEnum.QUERY.getValue(),
 				Collections.emptyMap());
-		List<DocJavaParameter> parameterList = getJavaParameterList(builder, docJavaMethod, frameworkAnnotations);
+		List<DocJavaParameter> parameterList = this.getJavaParameterList(builder, docJavaMethod, frameworkAnnotations);
 		if (parameterList.isEmpty()) {
 			AtomicInteger querySize = new AtomicInteger(paramList.size() + 1);
 			paramList.addAll(queryReqParamMap.values()
@@ -967,7 +967,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 			for (JavaAnnotation annotation : annotations) {
 				String annotationName = annotation.getType().getValue();
-				if (ignoreMvcParamWithAnnotation(annotationName)) {
+				if (this.ignoreMvcParamWithAnnotation(annotationName)) {
 					continue out;
 				}
 				if (frameworkAnnotations.getRequestParamAnnotation().getAnnotationName().equals(annotationName)
@@ -1026,7 +1026,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			if (requestFieldToUnderline && !isPathVariable) {
 				paramName = StringUtil.camelToUnderline(paramName);
 			}
-			// file upload
+			// Handle if it is file upload
 			if (JavaClassValidateUtil.isFile(typeName)) {
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
@@ -1049,9 +1049,12 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			boolean queryParam = Methods.GET.getValue().equals(docJavaMethod.getMethodType())
 					&& Methods.DELETE.getValue().equals(docJavaMethod.getMethodType()) && !isRequestBody
 					&& !isPathVariable;
+
+			String[] gicNameArr = DocClassUtil.getSimpleGicName(typeName);
+			// Handle if it is collection types
 			if (JavaClassValidateUtil.isCollection(fullyQualifiedName)
 					|| JavaClassValidateUtil.isArray(fullyQualifiedName)) {
-				String[] gicNameArr = DocClassUtil.getSimpleGicName(typeName);
+
 				String gicName = gicNameArr[0];
 				if (JavaClassValidateUtil.isArray(gicName)) {
 					gicName = gicName.substring(0, gicName.indexOf("["));
@@ -1122,6 +1125,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					}
 				}
 			}
+			// Handle if it is primitive types
 			else if (JavaClassValidateUtil.isPrimitive(fullyQualifiedName)) {
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
@@ -1139,74 +1143,32 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					docJavaMethod.setRequestSchema(map);
 				}
 			}
+			// Handle if it is map types
 			else if (JavaClassValidateUtil.isMap(fullyQualifiedName)) {
 				log.warning("When using smart-doc, it is not recommended to use Map to receive parameters, Check it in "
 						+ javaMethod.getDeclaringClass().getCanonicalName() + "#" + javaMethod.getName());
+
+				paramList.addAll(ParamsBuildHelper.buildMapParam(gicNameArr, DocGlobalConstants.EMPTY, 0,
+						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
+						docJavaMethod.getJsonViewClasses(), 0, Boolean.FALSE, 1, null));
+
 				// is map without Gic
 				if (JavaClassValidateUtil.isMap(typeName)) {
-					ApiParam apiParam = ApiParam.of()
-						.setField(paramName)
-						.setType(ParamTypeConstants.PARAM_TYPE_MAP)
-						.setId(paramList.size() + 1)
-						.setPathParam(isPathVariable)
-						.setQueryParam(queryParam)
-						.setDesc(comment.toString())
-						.setRequired(required)
-						.setVersion(DocGlobalConstants.DEFAULT_VERSION);
-					paramList.add(apiParam);
 					if (requestBodyCounter > 0) {
 						Map<String, Object> map = OpenApiSchemaUtil.mapTypeSchema("object");
 						docJavaMethod.setRequestSchema(map);
 					}
 					continue;
 				}
-				String[] gicNameArr = DocClassUtil.getSimpleGicName(typeName);
-
-				// get map key class
-				JavaClass mapKeyClass = builder.getClassByName(gicNameArr[0]);
-
+				// if map value is primitive
 				if (JavaClassValidateUtil.isPrimitive(gicNameArr[1])) {
-					ApiParam apiParam = ApiParam.of()
-						.setField(paramName)
-						.setType(ParamTypeConstants.PARAM_TYPE_MAP)
-						.setId(paramList.size() + 1)
-						.setPathParam(isPathVariable)
-						.setQueryParam(queryParam)
-						.setDesc(comment.toString())
-						.setRequired(required)
-						.setVersion(DocGlobalConstants.DEFAULT_VERSION);
-					paramList.add(apiParam);
 					if (requestBodyCounter > 0) {
 						Map<String, Object> map = OpenApiSchemaUtil.mapTypeSchema(gicNameArr[1]);
 						docJavaMethod.setRequestSchema(map);
 					}
 				}
-				else if (Objects.nonNull(mapKeyClass) && mapKeyClass.isEnum()
-						&& !mapKeyClass.getEnumConstants().isEmpty()) {
-					for (JavaField enumConstant : mapKeyClass.getEnumConstants()) {
-						ApiParam apiParam = ApiParam.of()
-							.setField(enumConstant.getName())
-							.setType(ParamTypeConstants.PARAM_TYPE_OBJECT)
-							.setClassName(gicNameArr[1])
-							.setDesc(Optional.ofNullable(builder.getClassByName(gicNameArr[1]))
-								.map(JavaClass::getComment)
-								.orElse(DocGlobalConstants.DEFAULT_MAP_KEY_DESC))
-							.setVersion(DocGlobalConstants.DEFAULT_VERSION)
-							.setId(paramList.size() + 1);
-						paramList.add(apiParam);
-						paramList.addAll(ParamsBuildHelper.buildParams(gicNameArr[1], DocGlobalConstants.PARAM_PREFIX,
-								1, String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
-								docJavaMethod.getJsonViewClasses(), apiParam.getId(), Boolean.FALSE, null));
-					}
-				}
-				else {
-					paramList.addAll(ParamsBuildHelper.buildParams(gicNameArr[1], DocGlobalConstants.EMPTY, 0,
-							String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
-							docJavaMethod.getJsonViewClasses(), 0, Boolean.FALSE, null));
-				}
-
 			}
-			// param is enum
+			// Handle if it is enum types
 			else if (javaClass.isEnum()) {
 				String enumName = JavaClassUtil.getEnumParams(javaClass);
 				Object value = JavaClassUtil.getEnumValue(javaClass, builder, isPathVariable || queryParam);
@@ -1227,7 +1189,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.setEnumValues(JavaClassUtil.getEnumValues(javaClass));
 				paramList.add(param);
 			}
-			// if it has annotation @RequestPart
+			// Handle if it has annotation @RequestPart
 			else if (isRequestPart) {
 				ApiParam param = ApiParam.of()
 					.setClassName(fullyQualifiedName)
@@ -1352,7 +1314,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				if (!mvcRequestAnnotations.contains(fullName) || paramAdded) {
 					continue;
 				}
-				if (ignoreMvcParamWithAnnotation(annotationName)) {
+				if (this.ignoreMvcParamWithAnnotation(annotationName)) {
 					continue out;
 				}
 
@@ -1614,9 +1576,9 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			Map<String, JavaType> actualTypesMap = JavaClassUtil.getActualTypesMap(parentClass);
 			List<JavaMethod> parentMethodList = parentClass.getMethods();
 			for (JavaMethod method : parentMethodList) {
-				docJavaMethods.add(convertToDocJavaMethod(apiConfig, projectBuilder, method, actualTypesMap));
+				docJavaMethods.add(this.convertToDocJavaMethod(apiConfig, projectBuilder, method, actualTypesMap));
 			}
-			docJavaMethods.addAll(getParentsClassMethods(apiConfig, projectBuilder, parentClass));
+			docJavaMethods.addAll(this.getParentsClassMethods(apiConfig, projectBuilder, parentClass));
 		}
 		return docJavaMethods;
 	}

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -142,11 +142,11 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 				continue;
 			}
 			if (needAllMethods || filterMethods.contains(method.getName())) {
-				docJavaMethods.add(convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
+				docJavaMethods.add(this.convertToDocJavaMethod(apiConfig, projectBuilder, method, null));
 			}
 		}
 		// add parent class methods
-		docJavaMethods.addAll(getParentsClassMethods(apiConfig, projectBuilder, cls));
+		docJavaMethods.addAll(this.getParentsClassMethods(apiConfig, projectBuilder, cls));
 		List<ApiMethodDoc> methodDocList = new ArrayList<>(methods.size());
 		int methodOrder = 0;
 		for (DocJavaMethod docJavaMethod : docJavaMethods) {
@@ -274,7 +274,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 	@Override
 	@SuppressWarnings("deprecation")
 	public boolean isEntryPoint(JavaClass cls, FrameworkAnnotations frameworkAnnotations) {
-		boolean isDefaultEntryPoint = defaultEntryPoint(cls, frameworkAnnotations);
+		boolean isDefaultEntryPoint = this.defaultEntryPoint(cls, frameworkAnnotations);
 		if (isDefaultEntryPoint) {
 			return true;
 		}

--- a/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SolonDocBuildTemplate.java
@@ -75,7 +75,7 @@ public class SolonDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 
 	@Override
 	public boolean isEntryPoint(JavaClass cls, FrameworkAnnotations frameworkAnnotations) {
-		boolean isDefaultEntryPoint = defaultEntryPoint(cls, frameworkAnnotations);
+		boolean isDefaultEntryPoint = this.defaultEntryPoint(cls, frameworkAnnotations);
 		if (isDefaultEntryPoint) {
 			return true;
 		}

--- a/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
@@ -220,7 +220,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 
 	@Override
 	public boolean isEntryPoint(JavaClass javaClass, FrameworkAnnotations frameworkAnnotations) {
-		boolean isDefaultEntryPoint = defaultEntryPoint(javaClass, frameworkAnnotations);
+		boolean isDefaultEntryPoint = this.defaultEntryPoint(javaClass, frameworkAnnotations);
 		if (isDefaultEntryPoint) {
 			return true;
 		}
@@ -256,7 +256,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 
 	@Override
 	public boolean isExceptionAdviceEntryPoint(JavaClass javaClass, FrameworkAnnotations frameworkAnnotations) {
-		return defaultExceptionAdviceEntryPoint(javaClass, frameworkAnnotations);
+		return this.defaultExceptionAdviceEntryPoint(javaClass, frameworkAnnotations);
 	}
 
 	@Override


### PR DESCRIPTION
fix: :bug: Fix issue where `JSON example` value is empty when `Map` key is an `enum` and value is a `primitive class`

- Correctly handle cases where the Map's key is an enum and its value is a primitive type, ensuring the JSON example value is populated appropriately.

- Refactor `JsonBuildHelper`  and `ParamsBuildHelper`