### PR TITLE
fix: :bug: resolve incorrect parsing of constants in `@JsonProperty` and `@JSONField` annotation

### DIFF
--- a/src/main/java/com/ly/doc/handler/IWebSocketRequestHandler.java
+++ b/src/main/java/com/ly/doc/handler/IWebSocketRequestHandler.java
@@ -20,6 +20,7 @@
  */
 package com.ly.doc.handler;
 
+import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocAnnotationConstants;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.model.request.ServerEndpoint;
@@ -28,6 +29,7 @@ import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaClass;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,11 +42,13 @@ public interface IWebSocketRequestHandler {
 
 	/**
 	 * handle class annotation `@ServerEndpoint`
+	 * @param projectBuilder the project configuration builder
 	 * @param javaAnnotation javaAnnotation @ServerEndpoint
 	 * @param cls JavaClass
 	 * @return ServerEndpoint
 	 */
-	default ServerEndpoint handleServerEndpoint(JavaClass cls, JavaAnnotation javaAnnotation) {
+	default ServerEndpoint handleServerEndpoint(ProjectDocConfigBuilder projectBuilder, JavaClass cls,
+			JavaAnnotation javaAnnotation) {
 		if (Objects.nonNull(cls.getTagByName(DocTags.IGNORE))) {
 			return null;
 		}
@@ -56,7 +60,9 @@ public interface IWebSocketRequestHandler {
 			.ifPresent(builder::setUrl);
 
 		// get subProtocols of annotation
-		builder.setSubProtocols(JavaClassUtil.getAnnotationValueStrings(javaAnnotation, "subprotocols"));
+		List<String> subProtocols = JavaClassUtil.getAnnotationValueStrings(projectBuilder, javaAnnotation,
+				"subprotocols");
+		builder.setSubProtocols(subProtocols);
 
 		// Handle 'decoders' property
 		builder.setDecoders(JavaClassUtil.getAnnotationValueClassNames(javaAnnotation, "decoders"));

--- a/src/main/java/com/ly/doc/helper/BaseHelper.java
+++ b/src/main/java/com/ly/doc/helper/BaseHelper.java
@@ -176,8 +176,10 @@ public abstract class BaseHelper {
 			// Handle @JSONField
 			if (DocAnnotationConstants.SHORT_JSON_FIELD.equals(annotationName)) {
 				if (null != annotation.getProperty(DocAnnotationConstants.NAME_PROP)) {
-					fieldJsonAnnotationInfo.setFieldName(StringUtil
-						.removeQuotes(annotation.getProperty(DocAnnotationConstants.NAME_PROP).toString()));
+					AnnotationValue annotationValue = annotation.getProperty(DocAnnotationConstants.NAME_PROP);
+					String fieldName = DocUtil.resolveAnnotationValue(projectBuilder.getApiConfig().getClassLoader(),
+							annotationValue);
+					fieldJsonAnnotationInfo.setFieldName(fieldName);
 				}
 			}
 
@@ -185,9 +187,9 @@ public abstract class BaseHelper {
 			else if (DocAnnotationConstants.SHORT_JSON_PROPERTY.equals(annotationName)
 					|| DocAnnotationConstants.GSON_ALIAS_NAME.equals(annotationName)) {
 				AnnotationValue annotationValue = annotation.getProperty(DocAnnotationConstants.VALUE_PROP);
-				if (null != annotationValue) {
-					fieldJsonAnnotationInfo.setFieldName(StringUtil.removeQuotes(annotationValue.toString()));
-				}
+				String fieldName = DocUtil.resolveAnnotationValue(projectBuilder.getApiConfig().getClassLoader(),
+						annotationValue);
+				fieldJsonAnnotationInfo.setFieldName(fieldName);
 			}
 			// Handle JSR303 required
 			if (JavaClassValidateUtil.isJSR303Required(annotationName) && !isResp) {

--- a/src/main/java/com/ly/doc/template/IWebSocketTemplate.java
+++ b/src/main/java/com/ly/doc/template/IWebSocketTemplate.java
@@ -39,10 +39,25 @@ import com.ly.doc.utils.DocUtil;
 import com.ly.doc.utils.JavaClassUtil;
 import com.power.common.util.StringUtil;
 import com.power.common.util.ValidateUtil;
-import com.thoughtworks.qdox.model.*;
+import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.JavaParameter;
+import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.impl.DefaultJavaParameterizedType;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -157,7 +172,7 @@ public interface IWebSocketTemplate {
 
 		webSocketRequestHandler = Objects.isNull(webSocketRequestHandler) ? DefaultWebSocketRequestHandler.getInstance()
 				: webSocketRequestHandler;
-		ServerEndpoint serverEndpoint = webSocketRequestHandler.handleServerEndpoint(javaClass,
+		ServerEndpoint serverEndpoint = webSocketRequestHandler.handleServerEndpoint(projectBuilder, javaClass,
 				serverEndpointAnnotation);
 
 		WebSocketDoc webSocketDoc = new WebSocketDoc();

--- a/src/main/java/com/ly/doc/utils/JavaClassUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassUtil.java
@@ -23,7 +23,13 @@
 package com.ly.doc.utils;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DefaultClassConstants;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.DocValidatorAnnotationEnum;
+import com.ly.doc.constants.JSRAnnotationConstants;
+import com.ly.doc.constants.JavaTypeConstants;
 import com.ly.doc.model.ApiConfig;
 import com.ly.doc.model.ApiDataDictionary;
 import com.ly.doc.model.DocJavaField;
@@ -34,7 +40,15 @@ import com.power.common.util.CollectionUtil;
 import com.power.common.util.EnumUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
-import com.thoughtworks.qdox.model.*;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+import com.thoughtworks.qdox.model.JavaGenericDeclaration;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.JavaParameterizedType;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.JavaTypeVariable;
 import com.thoughtworks.qdox.model.expression.AnnotationValue;
 import com.thoughtworks.qdox.model.expression.AnnotationValueList;
 import com.thoughtworks.qdox.model.expression.Constant;
@@ -43,8 +57,22 @@ import com.thoughtworks.qdox.model.impl.DefaultJavaField;
 import com.thoughtworks.qdox.model.impl.DefaultJavaParameterizedType;
 import org.apache.commons.lang3.StringUtils;
 
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -1323,11 +1351,13 @@ public class JavaClassUtil {
 	 * annotation. It handles both single string values and lists of string values. If the
 	 * property is not found or has no valid string values, an empty list is returned.
 	 * </p>
+	 * @param projectBuilder the project configuration builder
 	 * @param javaAnnotation the annotation containing the property
 	 * @param propertyName the name of the property to retrieve
 	 * @return a list of string values or an empty list if not present
 	 */
-	public static List<String> getAnnotationValueStrings(JavaAnnotation javaAnnotation, String propertyName) {
+	public static List<String> getAnnotationValueStrings(ProjectDocConfigBuilder projectBuilder,
+			JavaAnnotation javaAnnotation, String propertyName) {
 		AnnotationValue propertyValue = javaAnnotation.getProperty(propertyName);
 		if (propertyValue != null) {
 			if (propertyValue instanceof AnnotationValueList) {
@@ -1338,9 +1368,9 @@ public class JavaClassUtil {
 					.filter(StringUtil::isNotEmpty)
 					.collect(Collectors.toList());
 			}
-			if (propertyValue instanceof Constant) {
-				return Collections.singletonList(((Constant) propertyValue).getValue().toString());
-			}
+			String value = DocUtil.resolveAnnotationValue(projectBuilder.getApiConfig().getClassLoader(),
+					propertyValue);
+			return Collections.singletonList(value);
 		}
 		return Collections.emptyList();
 	}


### PR DESCRIPTION

- Fixed an issue where constants from a constant class in `@JsonProperty` and `@JSONField` annotations were not correctly parsed in generated documentation
- Fixed an issue where constants from a constant class in `@ServerEndpoint` subprotocols value

[issues 934](https://github.com/TongchengOpenSource/smart-doc/issues/934)