### PR TITLE
refactor(url): Refactor URL-related code

### DIFF
--- a/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
+++ b/src/main/java/com/ly/doc/builder/PostmanJsonBuilder.java
@@ -25,7 +25,12 @@ import com.ly.doc.constants.MediaType;
 import com.ly.doc.constants.Methods;
 import com.ly.doc.factory.BuildTemplateFactory;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.FormData;
 import com.ly.doc.model.postman.InfoBean;
 import com.ly.doc.model.postman.ItemBean;
 import com.ly.doc.model.postman.RequestItem;
@@ -42,7 +47,11 @@ import com.power.common.util.FileUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Postman Json Builder
@@ -151,7 +160,7 @@ public class PostmanJsonBuilder {
 		String shortUrl = DocPathUtil.toPostmanPath(apiMethodDoc.getPath());
 		String[] paths;
 		if (StringUtil.isNotEmpty(shortUrl)) {
-			paths = shortUrl.split("/");
+			paths = shortUrl.split(DocGlobalConstants.PATH_DELIMITER);
 		}
 		else {
 			paths = new String[0];
@@ -161,7 +170,7 @@ public class PostmanJsonBuilder {
 		// Add server path
 		if (CollectionUtil.isNotEmpty(urlBean.getPath()) && StringUtil.isNotEmpty(shortUrl)
 				&& !shortUrl.contains(serverPath)) {
-			String[] serverPaths = serverPath.split("/");
+			String[] serverPaths = serverPath.split(DocGlobalConstants.PATH_DELIMITER);
 			pathList.addAll(Arrays.asList(serverPaths));
 		}
 		// Add mapping path
@@ -170,7 +179,7 @@ public class PostmanJsonBuilder {
 				pathList.add(str);
 			}
 		}
-		if (StringUtil.isNotEmpty(shortUrl) && shortUrl.endsWith("/")) {
+		if (StringUtil.isNotEmpty(shortUrl) && shortUrl.endsWith(DocGlobalConstants.PATH_DELIMITER)) {
 			pathList.add("");
 		}
 

--- a/src/main/java/com/ly/doc/builder/ProjectDocConfigBuilder.java
+++ b/src/main/java/com/ly/doc/builder/ProjectDocConfigBuilder.java
@@ -24,7 +24,15 @@ import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.HighLightJsConstants;
 import com.ly.doc.constants.HighlightStyle;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiConstant;
+import com.ly.doc.model.ApiDataDictionary;
+import com.ly.doc.model.ApiErrorCodeDictionary;
+import com.ly.doc.model.ApiObjectReplacement;
+import com.ly.doc.model.BodyAdvice;
+import com.ly.doc.model.CustomField;
+import com.ly.doc.model.DocJavaField;
+import com.ly.doc.model.SourceCodePath;
 import com.ly.doc.utils.JavaClassUtil;
 import com.power.common.constants.Charset;
 import com.power.common.util.CollectionUtil;
@@ -40,7 +48,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -231,7 +249,7 @@ public class ProjectDocConfigBuilder {
 				}
 				String strPath = path.getPath();
 				if (StringUtil.isNotEmpty(strPath)) {
-					strPath = strPath.replace("\\", "/");
+					strPath = strPath.replace("\\", DocGlobalConstants.PATH_DELIMITER);
 					loadJavaSource(strPath, builder);
 				}
 			}

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -25,7 +25,14 @@ import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.MediaType;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiExceptionStatus;
+import com.ly.doc.model.ApiGroup;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.ApiSchema;
 import com.ly.doc.model.openapi.OpenApiTag;
 import com.ly.doc.utils.DocUtil;
 import com.ly.doc.utils.JsonUtil;
@@ -35,7 +42,13 @@ import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -92,7 +105,8 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 		json.put("swagger", "2.0");
 		json.put("info", buildInfo(config));
 		json.put("host", config.getServerUrl() == null ? "127.0.0.1" : config.getServerUrl());
-		json.put("basePath", StringUtils.isNotBlank(config.getPathPrefix()) ? config.getPathPrefix() : "/");
+		json.put("basePath", StringUtils.isNotBlank(config.getPathPrefix()) ? config.getPathPrefix()
+				: DocGlobalConstants.PATH_DELIMITER);
 		Set<OpenApiTag> tags = new HashSet<>();
 		json.put("tags", tags);
 		json.put("paths", buildPaths(config, apiSchema, tags));

--- a/src/main/java/com/ly/doc/handler/IRequestMappingHandler.java
+++ b/src/main/java/com/ly/doc/handler/IRequestMappingHandler.java
@@ -62,8 +62,10 @@ public interface IRequestMappingHandler {
 			String serverUrl = projectBuilder.getServerUrl();
 			String contextPath = projectBuilder.getApiConfig().getPathPrefix();
 			shortUrl = StringUtil.removeQuotes(shortUrl);
-			String url = DocUrlUtil.getMvcUrls(serverUrl, contextPath + "/" + controllerBaseUrl, shortUrl);
-			shortUrl = DocUrlUtil.getMvcUrls(DocGlobalConstants.EMPTY, contextPath + "/" + controllerBaseUrl, shortUrl);
+			String url = DocUrlUtil.getMvcUrls(serverUrl,
+					contextPath + DocGlobalConstants.PATH_DELIMITER + controllerBaseUrl, shortUrl);
+			shortUrl = DocUrlUtil.getMvcUrls(DocGlobalConstants.EMPTY,
+					contextPath + DocGlobalConstants.PATH_DELIMITER + controllerBaseUrl, shortUrl);
 			String urlSuffix = projectBuilder.getApiConfig().getUrlSuffix();
 			if (StringUtil.isEmpty(urlSuffix)) {
 				urlSuffix = StringUtil.EMPTY;

--- a/src/main/java/com/ly/doc/handler/JaxrsPathHandler.java
+++ b/src/main/java/com/ly/doc/handler/JaxrsPathHandler.java
@@ -21,7 +21,11 @@
 package com.ly.doc.handler;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.JAXRSAnnotations;
+import com.ly.doc.constants.JakartaJaxrsAnnotations;
+import com.ly.doc.constants.JavaTypeConstants;
+import com.ly.doc.constants.MediaType;
 import com.ly.doc.model.request.JaxrsPathMapping;
 import com.ly.doc.utils.DocUrlUtil;
 import com.ly.doc.utils.DocUtil;
@@ -30,7 +34,11 @@ import com.power.common.util.UrlUtil;
 import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaMethod;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -143,8 +151,9 @@ public class JaxrsPathHandler {
 			shortUrl = String.join(DocGlobalConstants.PATH_DELIMITER, DocGlobalConstants.PATH_DELIMITER, contextPath,
 					baseUrl, shortUrl);
 			if (urls.size() > 1) {
-				url = DocUrlUtil.getMvcUrls(serverUrl, contextPath + "/" + baseUrl, urls);
-				shortUrl = DocUrlUtil.getMvcUrls(DocGlobalConstants.EMPTY, contextPath + "/" + baseUrl, urls);
+				url = DocUrlUtil.getMvcUrls(serverUrl, contextPath + DocGlobalConstants.PATH_DELIMITER + baseUrl, urls);
+				shortUrl = DocUrlUtil.getMvcUrls(DocGlobalConstants.EMPTY,
+						contextPath + DocGlobalConstants.PATH_DELIMITER + baseUrl, urls);
 			}
 			for (Map.Entry<String, String> entry : constantsMap.entrySet()) {
 				String key = entry.getKey();

--- a/src/main/java/com/ly/doc/handler/SolonRequestMappingHandler.java
+++ b/src/main/java/com/ly/doc/handler/SolonRequestMappingHandler.java
@@ -22,6 +22,7 @@ package com.ly.doc.handler;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.Methods;
 import com.ly.doc.constants.SolonAnnotations;
 import com.ly.doc.function.RequestMappingFunc;
@@ -71,8 +72,8 @@ public class SolonRequestMappingHandler implements IRequestMappingHandler, IWebS
 					|| SolonAnnotations.REQUEST_MAPPING_FULLY.equals(annotationName)) {
 				ClassLoader classLoader = projectBuilder.getApiConfig().getClassLoader();
 				shortUrl = DocUtil.handleMappingValue(classLoader, annotation);
-				shortUrl = shortUrl.equals("/") ? "" : shortUrl; // There is no need to
-																	// add '/' to the end
+				// There is no need to add '/' to the end
+				shortUrl = shortUrl.equals(DocGlobalConstants.PATH_DELIMITER) ? "" : shortUrl;
 				Object produces = annotation.getNamedParameter("produces");
 				if (Objects.nonNull(produces)) {
 					mediaType = produces.toString();

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -21,13 +21,33 @@
 package com.ly.doc.template;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.ApiReqParamInTypeEnum;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.FormDataContentTypeEnum;
+import com.ly.doc.constants.JavaTypeConstants;
+import com.ly.doc.constants.MediaType;
+import com.ly.doc.constants.Methods;
+import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.handler.IHeaderHandler;
 import com.ly.doc.handler.IRequestMappingHandler;
 import com.ly.doc.helper.FormDataBuildHelper;
 import com.ly.doc.helper.JsonBuildHelper;
 import com.ly.doc.helper.ParamsBuildHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiExceptionStatus;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiMethodReqParam;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.DocJavaMethod;
+import com.ly.doc.model.DocJavaParameter;
+import com.ly.doc.model.DocMapping;
+import com.ly.doc.model.ExceptionAdviceMethod;
+import com.ly.doc.model.FormData;
 import com.ly.doc.model.annotation.EntryAnnotation;
 import com.ly.doc.model.annotation.ExceptionAdviceAnnotation;
 import com.ly.doc.model.annotation.FrameworkAnnotations;
@@ -35,14 +55,47 @@ import com.ly.doc.model.annotation.MappingAnnotation;
 import com.ly.doc.model.request.ApiRequestExample;
 import com.ly.doc.model.request.CurlRequest;
 import com.ly.doc.model.request.RequestMapping;
-import com.ly.doc.utils.*;
-import com.power.common.util.*;
-import com.thoughtworks.qdox.model.*;
+import com.ly.doc.utils.ApiParamTreeUtil;
+import com.ly.doc.utils.CurlUtil;
+import com.ly.doc.utils.DocClassUtil;
+import com.ly.doc.utils.DocUtil;
+import com.ly.doc.utils.HttpStatusUtil;
+import com.ly.doc.utils.JavaClassUtil;
+import com.ly.doc.utils.JavaClassValidateUtil;
+import com.ly.doc.utils.JavaFieldUtil;
+import com.ly.doc.utils.JsonUtil;
+import com.ly.doc.utils.OpenApiSchemaUtil;
+import com.ly.doc.utils.RequestExampleUtil;
+import com.ly.doc.utils.TornaUtil;
+import com.power.common.util.CollectionUtil;
+import com.power.common.util.RandomUtil;
+import com.power.common.util.StringUtil;
+import com.power.common.util.UrlUtil;
+import com.power.common.util.ValidateUtil;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.JavaParameter;
+import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.expression.AnnotationValue;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -1271,7 +1324,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			path = DocUtil.formatAndRemove(path, pathParamsMap);
 			String url = UrlUtil.urlJoin(path, queryParamsMap);
 			url = StringUtil.removeQuotes(url);
-			url = apiMethodDoc.getServerUrl() + "/" + url;
+			url = apiMethodDoc.getServerUrl() + DocGlobalConstants.PATH_DELIMITER + url;
 			url = UrlUtil.simplifyUrl(url);
 			CurlRequest curlRequest = CurlRequest.builder()
 				.setContentType(apiMethodDoc.getContentType())
@@ -1606,7 +1659,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 		}
 		DocletTag pageTag = method.getTagByName(DocTags.PAGE);
 		if (Objects.nonNull(method.getTagByName(DocTags.PAGE))) {
-			String pageUrl = projectBuilder.getServerUrl() + "/" + pageTag.getValue();
+			String pageUrl = projectBuilder.getServerUrl() + DocGlobalConstants.PATH_DELIMITER + pageTag.getValue();
 			docJavaMethod.setPage(UrlUtil.simplifyUrl(pageUrl));
 		}
 

--- a/src/main/java/com/ly/doc/template/RpcDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/RpcDocBuildTemplate.java
@@ -21,6 +21,7 @@
 package com.ly.doc.template;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
+import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.constants.DubboAnnotationConstants;
 import com.ly.doc.constants.FrameworkEnum;
@@ -40,7 +41,12 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.expression.AnnotationValue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -192,7 +198,7 @@ public class RpcDocBuildTemplate implements IDocBuildTemplate<RpcApiDoc>, IWebSo
 		apiDoc.setName(className);
 		apiDoc.setShortName(shortName);
 		apiDoc.setAlias(className);
-		apiDoc.setUri(builder.getServerUrl() + "/" + className);
+		apiDoc.setUri(builder.getServerUrl() + DocGlobalConstants.PATH_DELIMITER + className);
 		apiDoc.setProtocol(FrameworkEnum.DUBBO.getFramework());
 		if (builder.getApiConfig().isMd5EncryptedHtmlName()) {
 			String name = DocUtil.generateId(apiDoc.getName());

--- a/src/main/java/com/ly/doc/utils/BeetlTemplateUtil.java
+++ b/src/main/java/com/ly/doc/utils/BeetlTemplateUtil.java
@@ -20,6 +20,7 @@
  */
 package com.ly.doc.utils;
 
+import com.ly.doc.constants.DocGlobalConstants;
 import com.power.common.util.FileUtil;
 import org.beetl.core.Configuration;
 import org.beetl.core.GroupTemplate;
@@ -94,7 +95,8 @@ public class BeetlTemplateUtil {
 	 */
 	private static GroupTemplate getGroupTemplate(String path) {
 		try {
-			ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader("/" + path + "/");
+			ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(
+					DocGlobalConstants.PATH_DELIMITER + path + DocGlobalConstants.PATH_DELIMITER);
 			Configuration cfg = Configuration.defaultConfiguration();
 			return new GroupTemplate(resourceLoader, cfg);
 		}

--- a/src/main/java/com/ly/doc/utils/DocUrlUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUrlUtil.java
@@ -67,10 +67,10 @@ public class DocUrlUtil {
 				String trimUrl = Optional.ofNullable(StringUtil.trimBlank(urls.get(i))).orElse(StringUtil.EMPTY);
 				String url = baseServer;
 				if (StringUtil.isNotEmpty(trimBase)) {
-					url = url + "/" + trimBase;
+					url = url + DocGlobalConstants.PATH_DELIMITER + trimBase;
 				}
 				if (StringUtil.isNotEmpty(trimUrl)) {
-					url = url + "/" + trimUrl;
+					url = url + DocGlobalConstants.PATH_DELIMITER + trimUrl;
 				}
 				sb.append(UrlUtil.simplifyUrl(url));
 				if (i < size - 1) {
@@ -111,7 +111,7 @@ public class DocUrlUtil {
 		path = DocUtil.formatAndRemove(path, pathParamsMap);
 		String url = UrlUtil.urlJoin(path, queryParamsMap);
 		url = StringUtil.removeQuotes(url);
-		url = serverUrl + "/" + url;
+		url = serverUrl + DocGlobalConstants.PATH_DELIMITER + url;
 		url = UrlUtil.simplifyUrl(url);
 		return url;
 	}

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -531,7 +531,7 @@ public class DocUtil {
 		List<String> finalPaths = new ArrayList<>(pathList.size());
 		for (String pathParam : pathList) {
 			if (pathParam.startsWith("http:") || pathParam.startsWith("https:")) {
-				finalPaths.add(pathParam + "/");
+				finalPaths.add(pathParam + DocGlobalConstants.PATH_DELIMITER);
 				continue;
 			}
 			if (pathParam.startsWith("${")) {
@@ -593,7 +593,7 @@ public class DocUtil {
 		String[] urls = str.split(";");
 		int index = 0;
 		for (String url : urls) {
-			String[] strArr = url.split("/");
+			String[] strArr = url.split(DocGlobalConstants.PATH_DELIMITER);
 			for (int i = 0; i < strArr.length; i++) {
 				String pathParam = strArr[i];
 				if (pathParam.startsWith("http:") || pathParam.startsWith("https:") || pathParam.startsWith("{{")) {
@@ -652,7 +652,7 @@ public class DocUtil {
 	public static String handleMappingValue(ClassLoader classLoader, JavaAnnotation annotation) {
 		String url = getRequestMappingUrl(classLoader, annotation);
 		if (StringUtil.isEmpty(url)) {
-			return "/";
+			return DocGlobalConstants.PATH_DELIMITER;
 		}
 		else {
 			return StringUtil.trimBlank(url);
@@ -1415,7 +1415,7 @@ public class DocUtil {
 		if (StringUtil.isEmpty(url)) {
 			return new ArrayList<>(0);
 		}
-		String[] result = url.split("/");
+		String[] result = url.split(DocGlobalConstants.PATH_DELIMITER);
 		List<String> path = new ArrayList<>();
 		for (int i = 0; i < result.length; i++) {
 			if (StringUtil.isEmpty(result[i])) {
@@ -1424,7 +1424,7 @@ public class DocUtil {
 			if (i < result.length - 1) {
 				if ((result[i].startsWith("${") && !result[i].endsWith("}"))
 						&& (!result[i + 1].startsWith("${") && result[i + 1].endsWith("}"))) {
-					String merged = result[i] + "/" + result[i + 1];
+					String merged = result[i] + DocGlobalConstants.PATH_DELIMITER + result[i + 1];
 					path.add(merged);
 					i++;
 				}

--- a/src/main/java/com/ly/doc/utils/RequestExampleUtil.java
+++ b/src/main/java/com/ly/doc/utils/RequestExampleUtil.java
@@ -64,7 +64,7 @@ public class RequestExampleUtil {
 			// for post put
 			path = DocUtil.formatAndRemove(path, pathParamsMap);
 			body = UrlUtil.urlJoin(DocGlobalConstants.EMPTY, queryParamsMap).replace("?", DocGlobalConstants.EMPTY);
-			url = apiMethodDoc.getServerUrl() + "/" + path;
+			url = apiMethodDoc.getServerUrl() + DocGlobalConstants.PATH_DELIMITER + path;
 			url = UrlUtil.simplifyUrl(url);
 
 			if (requestExample.isJson()) {


### PR DESCRIPTION
- Use `DocGlobalConstants.PATH_DELIMITER` instead of hard-coded "/"
- Optimize URL concatenation logic in multiple places
- Standardize the handling of path separators