### PR TITLE
Fix issue If there are enumerations in the query request parameters, the generated request parameter comments will not include 'See'.

### DIFF
--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -782,7 +782,7 @@ public class ParamsBuildHelper extends BaseHelper {
 		paramList.add(param);
 	}
 
-	private static String handleEnumComment(JavaClass javaClass, ProjectDocConfigBuilder projectBuilder) {
+	public static String handleEnumComment(JavaClass javaClass, ProjectDocConfigBuilder projectBuilder) {
 		String comment = "";
 		if (!javaClass.isEnum()) {
 			return comment;

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1223,11 +1223,8 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			}
 			// Handle if it is enum types
 			else if (javaClass.isEnum()) {
-				String enumName = JavaClassUtil.getEnumParams(javaClass);
 				Object value = JavaClassUtil.getEnumValue(javaClass, builder, isPathVariable || queryParam);
-				if (Boolean.TRUE.equals(builder.getApiConfig().getInlineEnum())) {
-					comment.append("<br/>[Enum: ").append(StringUtil.removeQuotes(enumName)).append("]");
-				}
+				comment.append(ParamsBuildHelper.handleEnumComment(javaClass, builder));
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
 					.setId(paramList.size() + 1)


### PR DESCRIPTION
Fix issue If there are enumerations in the query request parameters, the generated request parameter comments will not include 'See'.