### PR TITLE
fix: Fix issue If the request parameter contains type "date" and the parameter name is endTime or beginTime, the resulting example value may be different from what you expect.

### DIFF
--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -348,8 +348,8 @@ public class ParamsBuildHelper extends BaseHelper {
 			// Analyzing Primitive Type Field
 			if (JavaClassValidateUtil.isPrimitive(subTypeName)) {
 				if (StringUtil.isEmpty(fieldValue)) {
-					fieldValue = StringUtil.isNotEmpty(fieldJsonFormatValue) ? fieldJsonFormatValue
-							: StringUtil.removeQuotes(DocUtil.getValByTypeAndFieldName(subTypeName, field.getName()));
+					fieldValue = StringUtil.isNotEmpty(fieldJsonFormatValue) ? fieldJsonFormatValue : StringUtil
+						.removeQuotes(DocUtil.getValByTypeAndFieldName(typeSimpleName, field.getName()));
 				}
 
 				ApiParam param = ApiParam.of()

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -168,8 +168,8 @@ public class DocUtil {
 		FIELD_VALUE.put("message-string", "success,fail".split(",")[RandomUtil.randomInt(0, 1)]);
 		FIELD_VALUE.put("date-string", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_DAY));
 		FIELD_VALUE.put("date-date", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_DAY));
-		FIELD_VALUE.put("begintime-date", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_DAY));
-		FIELD_VALUE.put("endtime-date", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_DAY));
+		FIELD_VALUE.put("begintime-date", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_SECOND));
+		FIELD_VALUE.put("endtime-date", DateTimeUtil.dateToStr(new Date(), DateTimeUtil.DATE_FORMAT_SECOND));
 		FIELD_VALUE.put("time-localtime",
 				LocalDateTime.now().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
 		FIELD_VALUE.put("state-int", String.valueOf(RandomUtil.randomInt(0, 10)));


### PR DESCRIPTION
Fix #947 

1. begintime-date and endtime-date are changed to yyyy-MM-dd HH:mm:ss.
2. 352 lines in ParamsBuildHelper, DocUtil. GetValByTypeAndFieldName parameters from subTypeName typeSimpleName instead