### PR TITLE
fix: :bug:  correct example value generation for enums annotated with `@JsonValue`

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1255,12 +1255,12 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				paramList.add(param);
 				paramList.addAll(ParamsBuildHelper.buildParams(typeName, DocGlobalConstants.PARAM_PREFIX, 1,
 						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
-						docJavaMethod.getJsonViewClasses(), 1, Boolean.FALSE, null));
+						docJavaMethod.getJsonViewClasses(), 1, isRequestBody, null));
 			}
 			else {
 				paramList.addAll(ParamsBuildHelper.buildParams(typeName, DocGlobalConstants.EMPTY, 0,
 						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
-						docJavaMethod.getJsonViewClasses(), 0, Boolean.FALSE, null));
+						docJavaMethod.getJsonViewClasses(), 0, isRequestBody, null));
 			}
 		}
 		return ApiParamTreeUtil.buildMethodReqParam(paramList, queryReqParamMap, pathReqParamMap,


### PR DESCRIPTION

- Issue: When an enum property or method is annotated with `@JsonValue`, the generated example value should reflect the annotated method’s return value instead of the enum name.
- Cause: The example generation logic did not recognize the `@JsonValue` annotation, resulting in the enum name being used as the example value.
- Fix: Updated the example generation logic to prioritize the value returned by methods annotated with @JsonValue.


#949 
