### PR TITLE
fix: :bug:  correct example value generation for enums annotated with `@JsonValue`

### DIFF
--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -29,8 +29,20 @@ import com.ly.doc.constants.JavaTypeConstants;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.extension.json.PropertyNameHelper;
 import com.ly.doc.extension.json.PropertyNamingStrategies;
-import com.ly.doc.model.*;
-import com.ly.doc.utils.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDataDictionary;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.CustomField;
+import com.ly.doc.model.CustomFieldInfo;
+import com.ly.doc.model.DocJavaField;
+import com.ly.doc.model.FieldJsonAnnotationInfo;
+import com.ly.doc.model.torna.EnumInfoAndValues;
+import com.ly.doc.utils.DocClassUtil;
+import com.ly.doc.utils.DocUtil;
+import com.ly.doc.utils.JavaClassUtil;
+import com.ly.doc.utils.JavaClassValidateUtil;
+import com.ly.doc.utils.JavaFieldUtil;
+import com.ly.doc.utils.ParamUtil;
 import com.power.common.model.EnumDictionary;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaAnnotation;
@@ -38,7 +50,15 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -245,7 +265,7 @@ public class ParamsBuildHelper extends BaseHelper {
 			// handle extension
 			Map<String, String> extensions = DocUtil.getCommentsByTag(field.getTagsByName(DocTags.EXTENSION),
 					DocTags.EXTENSION);
-			Map<String, Object> extensionParams = new HashMap<>();
+			Map<String, Object> extensionParams = new HashMap<>(extensions.size());
 			if (extensions != null && !extensions.isEmpty()) {
 				extensions.forEach((k, v) -> extensionParams.put(k, DocUtil.detectTagValue(v)));
 			}
@@ -367,8 +387,8 @@ public class ParamsBuildHelper extends BaseHelper {
 				// handle param
 				commonHandleParam(paramList, param, isRequired, comment.toString(), since, strRequired);
 
-				JavaClass enumClass = ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap,
-						fieldJsonFormatValue);
+				JavaClass enumClass = ParamUtil.handleSeeEnum(param, field, projectBuilder, isResp || jsonRequest,
+						tagsMap, fieldJsonFormatValue);
 				if (Objects.nonNull(enumClass)) {
 					String enumClassComment = DocGlobalConstants.EMPTY;
 					if (StringUtil.isNotEmpty(enumClass.getComment())) {
@@ -431,7 +451,8 @@ public class ParamsBuildHelper extends BaseHelper {
 				JavaClass javaClass = field.getType();
 				if (javaClass.isEnum()) {
 					comment.append(handleEnumComment(javaClass, projectBuilder));
-					ParamUtil.handleSeeEnum(param, field, projectBuilder, jsonRequest, tagsMap, fieldJsonFormatValue);
+					ParamUtil.handleSeeEnum(param, field, projectBuilder, isResp || jsonRequest, tagsMap,
+							fieldJsonFormatValue);
 					// hand Param
 					commonHandleParam(paramList, param, isRequired, comment + appendComment, since, strRequired);
 				}
@@ -484,10 +505,12 @@ public class ParamsBuildHelper extends BaseHelper {
 						if (!simpleName.equals(gName)) {
 							JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder().getClassByName(gName);
 							if (arraySubClass.isEnum()) {
-								Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder, Boolean.FALSE);
-								param.setValue("[\"" + value + "\"]")
-									.setEnumInfo(JavaClassUtil.getEnumInfo(arraySubClass, projectBuilder))
-									.setEnumValues(JavaClassUtil.getEnumValues(arraySubClass));
+								EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(arraySubClass,
+										projectBuilder, Boolean.FALSE);
+								if (Objects.nonNull(enumInfoAndValue)) {
+									param.setValue("[\"" + enumInfoAndValue.getValue() + "\"]")
+										.setEnumInfoAndValues(enumInfoAndValue);
+								}
 							}
 							else if (gName.length() == 1) {
 								// handle generic
@@ -782,6 +805,15 @@ public class ParamsBuildHelper extends BaseHelper {
 		paramList.add(param);
 	}
 
+	/**
+	 * Handles the generation of comments for enum types in a Java class. If the class is
+	 * an enum, it generates the corresponding enum comment based on the project
+	 * configuration; otherwise, it returns an empty comment string.
+	 * @param javaClass The JavaClass object containing class information.
+	 * @param projectBuilder The ProjectDocConfigBuilder object containing project
+	 * configuration information.
+	 * @return The generated enum comment string.
+	 */
 	public static String handleEnumComment(JavaClass javaClass, ProjectDocConfigBuilder projectBuilder) {
 		String comment = "";
 		if (!javaClass.isEnum()) {

--- a/src/main/java/com/ly/doc/model/ApiParam.java
+++ b/src/main/java/com/ly/doc/model/ApiParam.java
@@ -20,13 +20,13 @@
  */
 package com.ly.doc.model;
 
+import com.ly.doc.model.torna.EnumInfo;
+import com.ly.doc.model.torna.EnumInfoAndValues;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import com.ly.doc.model.torna.EnumInfo;
-
-import org.apache.commons.lang3.StringUtils;
 
 import static com.ly.doc.constants.DocGlobalConstants.PARAM_PREFIX;
 
@@ -111,12 +111,14 @@ public class ApiParam {
 	private boolean hasItems;
 
 	/**
-	 * enum values
+	 * enum values<br>
+	 * Use in openapi api document
 	 */
 	private List<String> enumValues;
 
 	/**
-	 * enum
+	 * enum Info<br>
+	 * Use in torna api document
 	 */
 	private EnumInfo enumInfo;
 
@@ -337,6 +339,15 @@ public class ApiParam {
 
 	public ApiParam setFormat(String format) {
 		this.format = format;
+		return this;
+	}
+
+	public ApiParam setEnumInfoAndValues(EnumInfoAndValues enumInfoAndValues) {
+		if (Objects.isNull(enumInfoAndValues)) {
+			return this;
+		}
+		this.enumInfo = enumInfoAndValues.getEnumInfo();
+		this.enumValues = enumInfoAndValues.getEnumValues();
 		return this;
 	}
 

--- a/src/main/java/com/ly/doc/model/torna/EnumInfo.java
+++ b/src/main/java/com/ly/doc/model/torna/EnumInfo.java
@@ -20,17 +20,35 @@
  */
 package com.ly.doc.model.torna;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
+ * Torna Enum Info
+ *
  * @author xingzi 2021/2/25 12:13
+ * @since 2.0.9
  **/
-public class EnumInfo {
+public class EnumInfo implements Serializable {
 
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = -4902969363646799679L;
+
+	/**
+	 * enum name
+	 */
 	private String name;
 
+	/**
+	 * enum description
+	 */
 	private String description;
 
+	/**
+	 * enum items
+	 */
 	private List<Item> items;
 
 	public String getName() {

--- a/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
+++ b/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
@@ -1,0 +1,70 @@
+package com.ly.doc.model.torna;
+
+import com.ly.doc.model.ApiParam;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Torna Enum Info And values
+ *
+ * @author linwumingshi
+ * @since 3.0.9
+ */
+public class EnumInfoAndValues implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = 6164712273272981975L;
+
+	/**
+	 * torna enumInfo
+	 */
+	private EnumInfo enumInfo;
+
+	/**
+	 * ApiParam enumValue<br>
+	 * Use in openapi api document
+	 * @see ApiParam#getEnumValues()
+	 */
+	private List<String> enumValues;
+
+	/**
+	 * ApiParam value
+	 * @see ApiParam#getValue()
+	 */
+	private Object value;
+
+	public static EnumInfoAndValues builder() {
+		return new EnumInfoAndValues();
+	}
+
+	public EnumInfo getEnumInfo() {
+		return enumInfo;
+	}
+
+	public EnumInfoAndValues setEnumInfo(EnumInfo enumInfo) {
+		this.enumInfo = enumInfo;
+		return this;
+	}
+
+	public List<String> getEnumValues() {
+		return enumValues;
+	}
+
+	public EnumInfoAndValues setEnumValues(List<String> enumValues) {
+		this.enumValues = enumValues;
+		return this;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public EnumInfoAndValues setValue(Object value) {
+		this.value = value;
+		return this;
+	}
+
+}

--- a/src/main/java/com/ly/doc/model/torna/Item.java
+++ b/src/main/java/com/ly/doc/model/torna/Item.java
@@ -20,10 +20,20 @@
  */
 package com.ly.doc.model.torna;
 
+import java.io.Serializable;
+
 /**
+ * Torna Enum Item.
+ *
  * @author xingzi 2021/2/25 12:29
+ * @since 2.0.9
  **/
-public class Item {
+public class Item implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = -1517636497626246584L;
 
 	/**
 	 * { * "name": "WAIT_PAY", * "type": "string", * "value": "0", * "description": "未支付"
@@ -31,10 +41,19 @@ public class Item {
 	 */
 	private String name;
 
+	/**
+	 * string, number, boolean, object, array
+	 */
 	private String type;
 
+	/**
+	 * value
+	 */
 	private String value;
 
+	/**
+	 * description
+	 */
 	private String description;
 
 	public Item() {

--- a/src/main/java/com/ly/doc/utils/JavaClassUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassUtil.java
@@ -34,6 +34,7 @@ import com.ly.doc.model.ApiConfig;
 import com.ly.doc.model.ApiDataDictionary;
 import com.ly.doc.model.DocJavaField;
 import com.ly.doc.model.torna.EnumInfo;
+import com.ly.doc.model.torna.EnumInfoAndValues;
 import com.ly.doc.model.torna.Item;
 import com.power.common.model.EnumDictionary;
 import com.power.common.util.CollectionUtil;
@@ -361,12 +362,33 @@ public class JavaClassUtil {
 			throw new RuntimeException(javaClass.getName() + " enum not existed");
 		}
 
+		// Default handling for enum values
+		return getEnumValue(javaClass, builder, formDataEnum, javaFields.get(0));
+	}
+
+	/**
+	 * Get the value of an enumConstant
+	 * <p>
+	 * This method retrieves the value of an enum based on its fields or methods. It
+	 * supports loading the enum class via reflection and determines the enum value based
+	 * on the presence of specific annotations such as {@code JsonValue}
+	 * @param javaClass The JavaClass object representing the enum class
+	 * @param builder A ProjectDocConfigBuilder object used to retrieve API configuration
+	 * and the class loader
+	 * @param formDataEnum A boolean indicating whether it is a form data enum, which
+	 * affects the logic for retrieving enum values
+	 * @param enumConstant The JavaField object representing the enum constant
+	 * @return Object The enum value, whose type depends on the specific enum definition
+	 * @throws RuntimeException If the enum constants do not exist
+	 */
+	public static Object getEnumValue(JavaClass javaClass, ProjectDocConfigBuilder builder, boolean formDataEnum,
+			JavaField enumConstant) {
 		// Try getting value from method with JsonValue annotation
 		String methodName = findMethodWithJsonValue(javaClass);
 		if (Objects.nonNull(methodName) && !formDataEnum) {
 			Class<?> enumClass = loadEnumClass(javaClass, builder);
 			if (Objects.nonNull(enumClass)) {
-				return EnumUtil.getFieldValueByMethod(enumClass, methodName);
+				return EnumUtil.getFieldValueByMethod(enumClass, methodName, enumConstant.getName());
 			}
 			return null;
 		}
@@ -382,7 +404,7 @@ public class JavaClassUtil {
 		}
 
 		// Default handling for enum values
-		return processDefaultEnumFields(javaFields, formDataEnum);
+		return processDefaultEnumFields(javaClass.getEnumConstants(), formDataEnum);
 	}
 
 	/**
@@ -497,6 +519,11 @@ public class JavaClassUtil {
 		return stringBuilder.toString();
 	}
 
+	/**
+	 * Gets the list of enum values for the given JavaClass.
+	 * @param javaClass The JavaClass representing the enum
+	 * @return A List of Strings containing the enum values
+	 */
 	public static List<String> getEnumValues(JavaClass javaClass) {
 		List<JavaField> javaFields = javaClass.getEnumConstants();
 		List<String> enums = new ArrayList<>();
@@ -560,7 +587,7 @@ public class JavaClassUtil {
 	 * @author chen qi
 	 * @since 1.0.0
 	 */
-	public static EnumInfo getEnumInfo(JavaClass javaClass, ProjectDocConfigBuilder builder) {
+	public static EnumInfo getEnumInfo(JavaClass javaClass, ProjectDocConfigBuilder builder, boolean formDataEnum) {
 		if (Objects.isNull(javaClass) || !javaClass.isEnum()) {
 			return null;
 		}
@@ -604,16 +631,26 @@ public class JavaClassUtil {
 			return enumInfo;
 		}
 
+		// Default Enum Processing (values, types, descriptions)
 		List<Item> collect = enumConstants.stream().map(cons -> {
 			Item item = new Item();
 			String name = cons.getName();
 			String enumComment = cons.getComment();
 			item.setName(name);
-			item.setType("string");
-			item.setValue(name);
+			if (formDataEnum) {
+				item.setValue(name);
+				item.setType("string");
+			}
+			else {
+				Object enumValue = getEnumValue(javaClass, builder, false, cons);
+				item.setValue(Objects.isNull(enumValue) ? null : String.valueOf(enumValue));
+				item.setType(Objects.isNull(enumValue) ? null
+						: DocClassUtil.processTypeNameForParams(enumValue.getClass().getCanonicalName()));
+			}
 			item.setDescription(enumComment);
 			return item;
 		}).collect(Collectors.toList());
+
 		enumInfo.setItems(collect);
 		return enumInfo;
 	}
@@ -1398,6 +1435,41 @@ public class JavaClassUtil {
 			return Collections.singletonList(annotationValue);
 		}
 		return Collections.emptyList();
+	}
+
+	/**
+	 * Retrieves enum information and values for a given Java class.
+	 * <p>
+	 * This method first gathers general information about the enum, then collects all
+	 * enum values and their descriptions. If the enum is used in a form, it only collects
+	 * names and sets the type as string.
+	 * @param javaClass The Java class object representing the enum.
+	 * @param builder The project documentation configuration builder, used to access
+	 * project-specific documentation settings.
+	 * @param formDataEnum A boolean indicating whether the enum is used in a form; true
+	 * if so, false otherwise.
+	 * @return An EnumInfoAndValues object containing both the enum information and its
+	 * values.
+	 */
+	public static EnumInfoAndValues getEnumInfoAndValue(JavaClass javaClass, ProjectDocConfigBuilder builder,
+			boolean formDataEnum) {
+		// Step 1: Retrieve EnumInfo (general enum info like name, description, etc.)
+		EnumInfo enumInfo = getEnumInfo(javaClass, builder, formDataEnum);
+
+		// Return if the enumInfo is null
+		if (enumInfo == null) {
+			return null;
+		}
+
+		// Step 2: Get the enum values based on whether it's formDataEnum or not
+		List<String> enumValues = enumInfo.getItems().stream().map(Item::getValue).collect(Collectors.toList());
+
+		// Step 3: Create the EnumInfoAndValues result
+		return EnumInfoAndValues.builder()
+			.setEnumInfo(enumInfo)
+			.setEnumValues(enumValues)
+			// Using the same method to get default value
+			.setValue(getEnumValue(javaClass, builder, formDataEnum));
 	}
 
 }

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -4,12 +4,19 @@ import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.torna.EnumInfoAndValues;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -61,10 +68,11 @@ public class ParamUtil {
 				javaField.getType().getGenericFullyQualifiedName())) {
 			param.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 		}
-		Object value = JavaClassUtil.getEnumValue(seeEnum, builder, !jsonRequest);
-		param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(value)));
-		param.setEnumValues(JavaClassUtil.getEnumValues(seeEnum));
-		param.setEnumInfo(JavaClassUtil.getEnumInfo(seeEnum, builder));
+		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder, !jsonRequest);
+		if (Objects.nonNull(enumInfoAndValue)) {
+			param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
+				.setEnumInfoAndValues(enumInfoAndValue);
+		}
 		// If the @JsonFormat annotation's shape attribute value is specified, use it as
 		// the parameter value
 		if (StringUtil.isNotEmpty(jsonFormatValue)) {

--- a/src/main/java/com/ly/doc/utils/TornaUtil.java
+++ b/src/main/java/com/ly/doc/utils/TornaUtil.java
@@ -26,10 +26,29 @@ package com.ly.doc.utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import com.ly.doc.constants.*;
-import com.ly.doc.model.*;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.MediaType;
+import com.ly.doc.constants.ParamTypeConstants;
+import com.ly.doc.constants.TornaConstants;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDocDict;
+import com.ly.doc.model.ApiErrorCode;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.BodyAdvice;
+import com.ly.doc.model.DataDict;
+import com.ly.doc.model.RpcJavaMethod;
 import com.ly.doc.model.rpc.RpcApiDependency;
-import com.ly.doc.model.torna.*;
+import com.ly.doc.model.torna.Apis;
+import com.ly.doc.model.torna.CommonErrorCode;
+import com.ly.doc.model.torna.DebugEnv;
+import com.ly.doc.model.torna.HttpParam;
+import com.ly.doc.model.torna.Item;
+import com.ly.doc.model.torna.TornaApi;
+import com.ly.doc.model.torna.TornaDic;
+import com.ly.doc.model.torna.TornaRequestInfo;
 import com.power.common.model.EnumDictionary;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.OkHttp3Util;
@@ -39,7 +58,12 @@ import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.JavaParameter;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import static com.ly.doc.constants.TornaConstants.ENUM_PUSH;
 import static com.ly.doc.constants.TornaConstants.PUSH;
@@ -315,6 +339,14 @@ public class TornaUtil {
 			if (Objects.equals(type, ParamTypeConstants.PARAM_TYPE_FILE) && apiParam.isHasItems()) {
 				type = TornaConstants.PARAM_TYPE_FILE_ARRAY;
 			}
+			if (Objects.nonNull(apiParam.getEnumInfo())) {
+				// Get type from enum items if available, with null check for items
+				List<Item> items = apiParam.getEnumInfo().getItems();
+				if (Objects.nonNull(items) && !items.isEmpty()) {
+					type = items.stream().map(Item::getType).findFirst().orElse(type);
+				}
+			}
+
 			httpParam.setType(type);
 			httpParam.setVersion(apiParam.getVersion());
 			httpParam.setRequired(apiParam.isRequired() ? TornaConstants.YES : TornaConstants.NO);


### PR DESCRIPTION
- Issue: When an enum property or method is annotated with `@JsonValue`, the generated example value should reflect the annotated method’s return value instead of the enum name.
- Cause: The example generation logic did not recognize the `@JsonValue` annotation, resulting in the enum name being used as the example value.
- Fix: Updated the example generation logic to prioritize the value returned by methods annotated with @JsonValue.


#949 
