### PR TITLE
fix: :bug:  correct example value generation for enums annotated with `@JsonValue`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,28 @@
             <url>https://github.com/shalousun</url>
         </developer>
     </developers>
+
     <properties>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
+        <beetl.version>3.17.0.RELEASE</beetl.version>
+        <common-util.version>2.2.7</common-util.version>
+        <qdox.version>2.0.3.4</qdox.version>
+        <datafaker.version>1.4.0</datafaker.version>
+        <gson.version>2.11.0</gson.version>
+        <eclipse.jgit.version>5.13.3.202401111512-r</eclipse.jgit.version>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
+
+        <!-- plugin version -->
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
+        <spring-javaformat-maven-plugin.version>0.0.43</spring-javaformat-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.6.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -46,37 +64,37 @@
         <dependency>
             <groupId>com.ibeetl</groupId>
             <artifactId>beetl</artifactId>
-            <version>3.17.0.RELEASE</version>
+            <version>${beetl.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ly.smart-doc</groupId>
             <artifactId>qdox</artifactId>
-            <version>2.0.3.4</version>
+            <version>${qdox.version}</version>
         </dependency>
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>1.4.0</version>
+            <version>${datafaker.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.shalousun</groupId>
             <artifactId>common-util</artifactId>
-            <version>2.2.6</version>
+            <version>${common-util.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.11.0</version>
+            <version>${gson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.13.3.202401111512-r</version>
+            <version>${eclipse.jgit.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -85,10 +103,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -96,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -110,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -124,7 +142,7 @@
             <plugin>
                 <groupId>io.spring.javaformat</groupId>
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
-                <version>0.0.43</version>
+                <version>${spring-javaformat-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -143,10 +161,10 @@
             <id>release</id>
             <build>
                 <plugins>
-                   <plugin>
+                    <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.6.0</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central-ly</publishingServerId>
@@ -156,7 +174,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/com/ly/doc/model/ApiParam.java
+++ b/src/main/java/com/ly/doc/model/ApiParam.java
@@ -20,13 +20,13 @@
  */
 package com.ly.doc.model;
 
+import com.ly.doc.model.torna.EnumInfo;
+import com.ly.doc.model.torna.EnumInfoAndValues;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import com.ly.doc.model.torna.EnumInfo;
-
-import org.apache.commons.lang3.StringUtils;
 
 import static com.ly.doc.constants.DocGlobalConstants.PARAM_PREFIX;
 
@@ -111,12 +111,14 @@ public class ApiParam {
 	private boolean hasItems;
 
 	/**
-	 * enum values
+	 * enum values<br>
+	 * Use in openapi api document
 	 */
 	private List<String> enumValues;
 
 	/**
-	 * enum
+	 * enum Info<br>
+	 * Use in torna api document
 	 */
 	private EnumInfo enumInfo;
 
@@ -337,6 +339,15 @@ public class ApiParam {
 
 	public ApiParam setFormat(String format) {
 		this.format = format;
+		return this;
+	}
+
+	public ApiParam setEnumInfoAndValues(EnumInfoAndValues enumInfoAndValues) {
+		if (Objects.isNull(enumInfoAndValues)) {
+			return this;
+		}
+		this.enumInfo = enumInfoAndValues.getEnumInfo();
+		this.enumValues = enumInfoAndValues.getEnumValues();
 		return this;
 	}
 

--- a/src/main/java/com/ly/doc/model/torna/EnumInfo.java
+++ b/src/main/java/com/ly/doc/model/torna/EnumInfo.java
@@ -20,17 +20,35 @@
  */
 package com.ly.doc.model.torna;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
+ * Torna Enum Info
+ *
  * @author xingzi 2021/2/25 12:13
+ * @since 2.0.9
  **/
-public class EnumInfo {
+public class EnumInfo implements Serializable {
 
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = -4902969363646799679L;
+
+	/**
+	 * enum name
+	 */
 	private String name;
 
+	/**
+	 * enum description
+	 */
 	private String description;
 
+	/**
+	 * enum items
+	 */
 	private List<Item> items;
 
 	public String getName() {

--- a/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
+++ b/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
@@ -1,0 +1,70 @@
+package com.ly.doc.model.torna;
+
+import com.ly.doc.model.ApiParam;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Torna Enum Info And values
+ *
+ * @author linwumingshi
+ * @since 3.0.9
+ */
+public class EnumInfoAndValues implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = 6164712273272981975L;
+
+	/**
+	 * torna enumInfo
+	 */
+	private EnumInfo enumInfo;
+
+	/**
+	 * ApiParam enumValue<br>
+	 * Use in openapi api document
+	 * @see ApiParam#getEnumValues()
+	 */
+	private List<String> enumValues;
+
+	/**
+	 * ApiParam value
+	 * @see ApiParam#getValue()
+	 */
+	private Object value;
+
+	public static EnumInfoAndValues builder() {
+		return new EnumInfoAndValues();
+	}
+
+	public EnumInfo getEnumInfo() {
+		return enumInfo;
+	}
+
+	public EnumInfoAndValues setEnumInfo(EnumInfo enumInfo) {
+		this.enumInfo = enumInfo;
+		return this;
+	}
+
+	public List<String> getEnumValues() {
+		return enumValues;
+	}
+
+	public EnumInfoAndValues setEnumValues(List<String> enumValues) {
+		this.enumValues = enumValues;
+		return this;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public EnumInfoAndValues setValue(Object value) {
+		this.value = value;
+		return this;
+	}
+
+}

--- a/src/main/java/com/ly/doc/model/torna/Item.java
+++ b/src/main/java/com/ly/doc/model/torna/Item.java
@@ -20,10 +20,20 @@
  */
 package com.ly.doc.model.torna;
 
+import java.io.Serializable;
+
 /**
+ * Torna Enum Item.
+ *
  * @author xingzi 2021/2/25 12:29
+ * @since 2.0.9
  **/
-public class Item {
+public class Item implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = -1517636497626246584L;
 
 	/**
 	 * { * "name": "WAIT_PAY", * "type": "string", * "value": "0", * "description": "未支付"
@@ -31,10 +41,19 @@ public class Item {
 	 */
 	private String name;
 
+	/**
+	 * string, number, boolean, object, array
+	 */
 	private String type;
 
+	/**
+	 * value
+	 */
 	private String value;
 
+	/**
+	 * description
+	 */
 	private String description;
 
 	public Item() {

--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -728,7 +728,7 @@ public class DocUtil {
 
 	private static Map<String, String> getCommentsByTag(List<DocletTag> paramTags, final String tagName,
 			String className, String tagValNullMsg, String tagValErrorMsg) {
-		Map<String, String> paramTagMap = new HashMap<>(16);
+		Map<String, String> paramTagMap = new HashMap<>(paramTags.size());
 		for (DocletTag docletTag : paramTags) {
 			String value = docletTag.getValue();
 			if (StringUtil.isEmpty(value) && StringUtil.isNotEmpty(className)) {

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -4,12 +4,19 @@ import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocTags;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.torna.EnumInfoAndValues;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -61,10 +68,11 @@ public class ParamUtil {
 				javaField.getType().getGenericFullyQualifiedName())) {
 			param.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 		}
-		Object value = JavaClassUtil.getEnumValue(seeEnum, builder, !jsonRequest);
-		param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(value)));
-		param.setEnumValues(JavaClassUtil.getEnumValues(seeEnum));
-		param.setEnumInfo(JavaClassUtil.getEnumInfo(seeEnum, builder));
+		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder, !jsonRequest);
+		if (Objects.nonNull(enumInfoAndValue)) {
+			param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
+				.setEnumInfoAndValues(enumInfoAndValue);
+		}
 		// If the @JsonFormat annotation's shape attribute value is specified, use it as
 		// the parameter value
 		if (StringUtil.isNotEmpty(jsonFormatValue)) {

--- a/src/main/java/com/ly/doc/utils/TornaUtil.java
+++ b/src/main/java/com/ly/doc/utils/TornaUtil.java
@@ -26,10 +26,29 @@ package com.ly.doc.utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import com.ly.doc.constants.*;
-import com.ly.doc.model.*;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.MediaType;
+import com.ly.doc.constants.ParamTypeConstants;
+import com.ly.doc.constants.TornaConstants;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDocDict;
+import com.ly.doc.model.ApiErrorCode;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.BodyAdvice;
+import com.ly.doc.model.DataDict;
+import com.ly.doc.model.RpcJavaMethod;
 import com.ly.doc.model.rpc.RpcApiDependency;
-import com.ly.doc.model.torna.*;
+import com.ly.doc.model.torna.Apis;
+import com.ly.doc.model.torna.CommonErrorCode;
+import com.ly.doc.model.torna.DebugEnv;
+import com.ly.doc.model.torna.HttpParam;
+import com.ly.doc.model.torna.Item;
+import com.ly.doc.model.torna.TornaApi;
+import com.ly.doc.model.torna.TornaDic;
+import com.ly.doc.model.torna.TornaRequestInfo;
 import com.power.common.model.EnumDictionary;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.OkHttp3Util;
@@ -39,7 +58,12 @@ import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.JavaParameter;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import static com.ly.doc.constants.TornaConstants.ENUM_PUSH;
 import static com.ly.doc.constants.TornaConstants.PUSH;
@@ -315,6 +339,14 @@ public class TornaUtil {
 			if (Objects.equals(type, ParamTypeConstants.PARAM_TYPE_FILE) && apiParam.isHasItems()) {
 				type = TornaConstants.PARAM_TYPE_FILE_ARRAY;
 			}
+			if (Objects.nonNull(apiParam.getEnumInfo())) {
+				// Get type from enum items if available, with null check for items
+				List<Item> items = apiParam.getEnumInfo().getItems();
+				if (Objects.nonNull(items) && !items.isEmpty()) {
+					type = items.stream().map(Item::getType).findFirst().orElse(type);
+				}
+			}
+
 			httpParam.setType(type);
 			httpParam.setVersion(apiParam.getVersion());
 			httpParam.setRequired(apiParam.isRequired() ? TornaConstants.YES : TornaConstants.NO);


### PR DESCRIPTION
- Issue: When an enum property or method is annotated with `@JsonValue`, the generated example value should reflect the annotated method’s return value instead of the enum name.
- Cause: The example generation logic did not recognize the `@JsonValue` annotation, resulting in the enum name being used as the example value.
- Fix: Updated the example generation logic to prioritize the value returned by methods annotated with @JsonValue.



Fix issue #949 