### PR TITLE
 refactor (Enum): Optimize the handling logic for enum parameter types

### DIFF
--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -509,7 +509,8 @@ public class ParamsBuildHelper extends BaseHelper {
 										projectBuilder, Boolean.FALSE);
 								if (Objects.nonNull(enumInfoAndValue)) {
 									param.setValue("[\"" + enumInfoAndValue.getValue() + "\"]")
-										.setEnumInfoAndValues(enumInfoAndValue);
+										.setEnumInfoAndValues(enumInfoAndValue)
+										.setType(enumInfoAndValue.getType());
 								}
 							}
 							else if (gName.length() == 1) {

--- a/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
+++ b/src/main/java/com/ly/doc/model/torna/EnumInfoAndValues.java
@@ -36,6 +36,12 @@ public class EnumInfoAndValues implements Serializable {
 	 */
 	private Object value;
 
+	/**
+	 * ApiParam value default enum; when type is not enum type, will set this type to
+	 * {@link ApiParam#setType(String)}
+	 */
+	private String type;
+
 	public static EnumInfoAndValues builder() {
 		return new EnumInfoAndValues();
 	}
@@ -64,6 +70,15 @@ public class EnumInfoAndValues implements Serializable {
 
 	public EnumInfoAndValues setValue(Object value) {
 		this.value = value;
+		return this;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public EnumInfoAndValues setType(String type) {
+		this.type = type;
 		return this;
 	}
 

--- a/src/main/java/com/ly/doc/model/torna/Item.java
+++ b/src/main/java/com/ly/doc/model/torna/Item.java
@@ -20,6 +20,8 @@
  */
 package com.ly.doc.model.torna;
 
+import com.google.gson.annotations.Expose;
+
 import java.io.Serializable;
 
 /**
@@ -56,6 +58,13 @@ public class Item implements Serializable {
 	 */
 	private String description;
 
+	/**
+	 * valueObject; A temporary variable used to store the object form of the value. This
+	 * field will not be serialized or deserialized.
+	 */
+	@Expose(serialize = false, deserialize = false)
+	private Object valueObject;
+
 	public Item() {
 	}
 
@@ -64,6 +73,7 @@ public class Item implements Serializable {
 		this.type = type;
 		this.value = value;
 		this.description = description;
+		this.valueObject = name;
 	}
 
 	public String getName() {
@@ -96,6 +106,14 @@ public class Item implements Serializable {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public Object getValueObject() {
+		return valueObject;
+	}
+
+	public void setValueObject(Object valueObject) {
+		this.valueObject = valueObject;
 	}
 
 }

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -252,11 +252,11 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 	 * @param apiMethodDocs A list of method documentation objects corresponding to the
 	 * methods within the class.
 	 * @param order The sorting order for the generated API documentation entry.
-	 * @param isUseMD5 Flag indicating whether to use MD5 hashing to generate a unique
+	 * @param isUseMd5 Flag indicating whether to use MD5 hashing to generate a unique
 	 * alias for the documented class.
 	 */
 	default void handleApiDoc(JavaClass cls, List<ApiDoc> apiDocList, List<ApiMethodDoc> apiMethodDocs, int order,
-			boolean isUseMD5) {
+			boolean isUseMd5) {
 		String controllerName = cls.getName();
 		ApiDoc apiDoc = new ApiDoc();
 		String classAuthor = JavaClassUtil.getClassTagsValue(cls, DocTags.AUTHOR, Boolean.TRUE);
@@ -277,7 +277,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 		String[] tags = tagSet.toArray(new String[] {});
 		apiDoc.setTags(tags);
 
-		if (isUseMD5) {
+		if (isUseMd5) {
 			String name = DocUtil.generateId(apiDoc.getName());
 			apiDoc.setAlias(name);
 		}
@@ -1131,8 +1131,11 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 						.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
 					EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder,
 							Boolean.TRUE);
-					param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
-						.setEnumInfoAndValues(enumInfoAndValue);
+					if (Objects.nonNull(enumInfoAndValue)) {
+						param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
+							.setEnumInfoAndValues(enumInfoAndValue)
+							.setType(enumInfoAndValue.getType());
+					}
 
 					paramList.add(param);
 					if (requestBodyCounter > 0) {
@@ -1237,9 +1240,12 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.setVersion(DocGlobalConstants.DEFAULT_VERSION);
 
 				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder,
-						isPathVariable || queryParam);
-				param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
-					.setEnumInfoAndValues(enumInfoAndValue);
+						isPathVariable || queryParam || isRequestParam);
+				if (Objects.nonNull(enumInfoAndValue)) {
+					param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
+						.setEnumInfoAndValues(enumInfoAndValue)
+						.setType(enumInfoAndValue.getType());
+				}
 
 				paramList.add(param);
 			}

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -71,7 +71,8 @@ public class ParamUtil {
 		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder, !jsonRequest);
 		if (Objects.nonNull(enumInfoAndValue)) {
 			param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
-				.setEnumInfoAndValues(enumInfoAndValue);
+				.setEnumInfoAndValues(enumInfoAndValue)
+				.setType(enumInfoAndValue.getType());
 		}
 		// If the @JsonFormat annotation's shape attribute value is specified, use it as
 		// the parameter value

--- a/src/main/java/com/ly/doc/utils/TornaUtil.java
+++ b/src/main/java/com/ly/doc/utils/TornaUtil.java
@@ -45,7 +45,6 @@ import com.ly.doc.model.torna.Apis;
 import com.ly.doc.model.torna.CommonErrorCode;
 import com.ly.doc.model.torna.DebugEnv;
 import com.ly.doc.model.torna.HttpParam;
-import com.ly.doc.model.torna.Item;
 import com.ly.doc.model.torna.TornaApi;
 import com.ly.doc.model.torna.TornaDic;
 import com.ly.doc.model.torna.TornaRequestInfo;
@@ -338,13 +337,6 @@ public class TornaUtil {
 			String type = apiParam.getType();
 			if (Objects.equals(type, ParamTypeConstants.PARAM_TYPE_FILE) && apiParam.isHasItems()) {
 				type = TornaConstants.PARAM_TYPE_FILE_ARRAY;
-			}
-			if (Objects.nonNull(apiParam.getEnumInfo())) {
-				// Get type from enum items if available, with null check for items
-				List<Item> items = apiParam.getEnumInfo().getItems();
-				if (Objects.nonNull(items) && !items.isEmpty()) {
-					type = items.stream().map(Item::getType).findFirst().orElse(type);
-				}
 			}
 
 			httpParam.setType(type);


### PR DESCRIPTION
- Add a `type` field in the `EnumInfoAndValues` class to store the parameter type.
- Modify the enum processing method in the `JavaClassUtil` class to include type information.
- Update the enum parameter processing logic in the `IRestDocTemplate` interface.
- Adjust the `Item` class to add a `valueObject` field for storing value objects.
- Optimize the enum parameter processing in `ParamsBuildHelper` and `ParamUtil`.
- Remove redundant enum type checks in `TornaUtil`.