### PR TITLE
ci: :construction_worker: add PR comment notification for build and API doc generation

### DIFF
--- a/.github/workflows/build-and-run-example-project.yml
+++ b/.github/workflows/build-and-run-example-project.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build:
-    if: ${{ github.repository == 'TongchengOpenSource/smart-doc' && github.event.pull_request.changed_files > 0 }} # Run this job only if there are file changes
     runs-on: ubuntu-latest
 
     steps:
@@ -339,3 +338,40 @@ jobs:
         with:
           name: error-log-${{ runner.os }}-grpc-api-doc
           path: logs
+
+  write-comment:
+    if: ${{ always() }}
+    name: write comment to pr
+    needs: [build, maven-plugin-build, generate-api-docs, generate-grpc-api-doc]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set status message
+        id: set-status
+        run: |
+          job_status=""
+          
+          # Set the job status message
+          if [ ${{ needs.build.result }} == 'success' ] && [ ${{ needs.maven-plugin-build.result }} == 'success' ] && [ ${{ needs.generate-api-docs.result }} == 'success' ] && [ ${{ needs.generate-grpc-api-doc.result }} == 'success' ]; then
+            job_status=":green_heart: All jobs completed successfully! :tada:"
+          else
+            job_status=":x: Some jobs failed. Please check the details."
+          fi
+            
+          echo "job_status=$job_status" >> $GITHUB_ENV
+
+      - name: Comment on the pull request
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            Pull requests [#${{ github.event.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}) report:
+            ${{ env.job_status }}  
+            [DETAILS](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            
+            - ${{ needs.build.result == 'success' && '✅' || '❌' }} - build: ${{ needs.build.result }}
+            - ${{ needs.maven-plugin-build.result == 'success' && '✅' || '❌' }} - maven-plugin-build: ${{ needs.maven-plugin-build.result }}
+            - ${{ needs.generate-api-docs.result == 'success' && '✅' || '❌' }} - generate-api-docs(rest, dubbo, javadoc, websocket): ${{ needs.generate-api-docs.result }}
+            - ${{ needs.generate-grpc-api-doc.result == 'success' && '✅' || '❌' }} - generate-grpc-api-doc(ubuntu-latest, macos-latest, windows-latest): ${{ needs.generate-grpc-api-doc.result }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -11,15 +11,13 @@ jobs:
       pull-requests: write
     name: Say thanks for the PR and hint to document
     steps:
-      - name: comment on the pull request
-        uses: hasura/comment-progress@v2.3.0
+      - name: Comment on the pull request
+        uses: peter-evans/create-or-update-comment@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          number: ${{ github.event.number }}
-          id: thanks-and-hint-to-document
-          recreate: true
-          message: |
+          issue-number: ${{ github.event.number }}
+          body: |
             Thanks for your this PR.  :pray: 
             Please check again for your PR changes whether contains any usage configuration change such as `Add new configuration`, `Change default value of configuration`.
             If so, please add or update documents(markdown type) in `docs/` for repository [smart-doc-group/smart-doc-group.github.io](https://github.com/smart-doc-group/smart-doc-group.github.io/tree/master/docs)


### PR DESCRIPTION
ci: :construction_worker: Add PR comment notification for build and API doc generation

- Replace `hasura/comment-progress@v2.3.0` with `peter-evans/create-or-update-comment@v4`
- Add new job `write-comment` in GitHub Actions workflow
- The job runs after `build`, `maven-plugin-build`, `generate-api-docs`, and `generate-grpc-api-docs`
- It checks the status of these jobs and posts an appropriate message to the PR with a link to the workflow run
- Improves visibility and provides quick feedback on the CI/CD process for each PR

## write-comment example
![write-comment example](https://github.com/user-attachments/assets/2d19a4d7-f423-4043-92be-37d7ded18315)


