### PR TITLE
fix: Fixed issue caused by isQueryParam error

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1100,9 +1100,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				continue;
 			}
 
-			boolean queryParam = Methods.GET.getValue().equals(docJavaMethod.getMethodType())
-					&& Methods.DELETE.getValue().equals(docJavaMethod.getMethodType()) && !isRequestBody
-					&& !isPathVariable;
+			boolean queryParam = !isRequestBody && !isPathVariable;
 
 			String[] gicNameArr = DocClassUtil.getSimpleGicName(typeName);
 			// Handle if it is collection types


### PR DESCRIPTION
This problem can cause the `@RequestParam`  parameter of the POST request to be placed in the body parameter, and because the parameter is placed incorrectly, may cause the object's nested parameter structure to be incorrect.

fix  #953 .

The root cause of this BUG is the incorrect modification in #808  to fix #799