### PR TITLE
ci: :green_heart: add permissions for write comment to pr

### DIFF
--- a/.github/workflows/build-and-run-example-project.yml
+++ b/.github/workflows/build-and-run-example-project.yml
@@ -344,6 +344,8 @@ jobs:
     name: write comment to pr
     needs: [build, maven-plugin-build, generate-api-docs, generate-grpc-api-doc]
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     timeout-minutes: 5
     steps:
       - name: Set status message


### PR DESCRIPTION
- Add 'pull-requests: write' permissions to the 'write comment to pr' job
- This change enables the job to post comments on pull requests