### PR TITLE
feat(enum): Modify the enumeration example value generation rule

### DIFF
--- a/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
@@ -174,7 +174,7 @@ public class FormDataBuildHelper extends BaseHelper {
 				formDataList.add(formData);
 			}
 			else if (javaClass.isEnum()) {
-				Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.TRUE);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder);
 				if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
 					value = ParamUtil.formatMockValue(tagsMap.get(DocTags.MOCK));
 				}

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -60,8 +60,7 @@ public class JsonBuildHelper extends BaseHelper {
 			return "File download.";
 		}
 		if (method.getReturns().isEnum() && Objects.isNull(responseBodyAdvice)) {
-			return StringUtil
-				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), builder, Boolean.FALSE)));
+			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), builder)));
 		}
 		if (method.getReturns().isPrimitive() && Objects.isNull(responseBodyAdvice)) {
 			String typeName = method.getReturnType().getCanonicalName();
@@ -158,8 +157,7 @@ public class JsonBuildHelper extends BaseHelper {
 
 		// Handle enum types
 		if (javaClass.isEnum()) {
-			return StringUtil
-				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE)));
+			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, projectBuilder)));
 		}
 
 		StringBuilder result = new StringBuilder();
@@ -389,8 +387,7 @@ public class JsonBuildHelper extends BaseHelper {
 								JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder()
 									.getClassByName(gicName);
 								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder,
-											Boolean.FALSE);
+									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder);
 									result.append("[").append(value).append("],");
 									continue;
 								}
@@ -463,7 +460,7 @@ public class JsonBuildHelper extends BaseHelper {
 							// if has Annotation @JsonSerialize And using
 							// ToStringSerializer && isResp
 							else if (toStringSerializer && isResp) {
-								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder);
 								result.append(value).append(",");
 							}
 							// if has @JsonFormat
@@ -471,7 +468,7 @@ public class JsonBuildHelper extends BaseHelper {
 								result.append(fieldJsonFormatValue).append(",");
 							}
 							else {
-								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.FALSE);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder);
 								result.append(value).append(",");
 							}
 						}

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -502,12 +502,13 @@ public class ParamsBuildHelper extends BaseHelper {
 							if (arraySubClass.isEnum()) {
 								comment.append(handleEnumComment(arraySubClass, projectBuilder));
 								param.setDesc(comment.toString());
+								param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
+
 								EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(arraySubClass,
-										projectBuilder, Boolean.FALSE);
+										projectBuilder);
 								if (Objects.nonNull(enumInfoAndValue)) {
 									param.setValue("[\"" + enumInfoAndValue.getValue() + "\"]")
-										.setEnumInfoAndValues(enumInfoAndValue)
-										.setType(enumInfoAndValue.getType());
+										.setEnumInfoAndValues(enumInfoAndValue);
 								}
 							}
 							else if (gName.length() == 1) {

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -457,6 +457,13 @@ public class ApiConfig {
 	 */
 	private boolean addDefaultHttpStatuses;
 
+	/**
+	 * Show enum name for example
+	 *
+	 * @since 3.1.0
+	 */
+	private boolean enumNameExample = Boolean.FALSE;
+
 	public static ApiConfig getInstance() {
 		return instance;
 	}
@@ -1136,6 +1143,14 @@ public class ApiConfig {
 
 	public void setAddDefaultHttpStatuses(boolean addDefaultHttpStatuses) {
 		this.addDefaultHttpStatuses = addDefaultHttpStatuses;
+	}
+
+	public boolean isEnumNameExample() {
+		return enumNameExample;
+	}
+
+	public void setEnumNameExample(boolean enumNameExample) {
+		this.enumNameExample = enumNameExample;
 	}
 
 }

--- a/src/main/java/com/ly/doc/model/torna/Item.java
+++ b/src/main/java/com/ly/doc/model/torna/Item.java
@@ -58,13 +58,6 @@ public class Item implements Serializable {
 	 */
 	private String description;
 
-	/**
-	 * valueObject; A temporary variable used to store the object form of the value. This
-	 * field will not be serialized or deserialized.
-	 */
-	@Expose(serialize = false, deserialize = false)
-	private Object valueObject;
-
 	public Item() {
 	}
 
@@ -73,7 +66,6 @@ public class Item implements Serializable {
 		this.type = type;
 		this.value = value;
 		this.description = description;
-		this.valueObject = name;
 	}
 
 	public String getName() {
@@ -106,14 +98,6 @@ public class Item implements Serializable {
 
 	public void setDescription(String description) {
 		this.description = description;
-	}
-
-	public Object getValueObject() {
-		return valueObject;
-	}
-
-	public void setValueObject(Object valueObject) {
-		this.valueObject = valueObject;
 	}
 
 }

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1167,8 +1167,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 						.setQueryParam(isQueryParam)
 						.setId(paramList.size() + 1)
 						.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
-					EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder,
-							Boolean.TRUE);
+					EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder);
 					if (Objects.nonNull(enumInfoAndValue)) {
 						param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 							.setEnumInfoAndValues(enumInfoAndValue);
@@ -1276,8 +1275,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.setRequired(required)
 					.setVersion(DocGlobalConstants.DEFAULT_VERSION);
 
-				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder,
-						isPathVariable || isQueryParam);
+				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder);
 				if (Objects.nonNull(enumInfoAndValue)) {
 					param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 						.setEnumInfoAndValues(enumInfoAndValue)
@@ -1474,7 +1472,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (pathParamsMap.containsKey(paramName)) {
@@ -1488,7 +1486,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (queryParamsMap.containsKey(paramName)) {
@@ -1565,7 +1563,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				String value;
 				JavaClass javaClass1 = configBuilder.getClassByName(gicName);
 				if (Objects.nonNull(javaClass1) && javaClass1.isEnum()) {
-					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, configBuilder, Boolean.TRUE));
+					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, configBuilder));
 				}
 				else {
 					value = RandomUtil.randomValueByType(gicName);
@@ -1583,7 +1581,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			// enum type
 			else if (javaClass.isEnum()) {
 				// do nothing
-				Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
+				Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
 				String strVal = StringUtil.removeQuotes(String.valueOf(value));
 				FormData formData = new FormData();
 				formData.setKey(paramName);

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -450,7 +450,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 				}
 				JavaClass gicJavaClass = builder.getJavaProjectBuilder().getClassByName(gicName);
 				if (gicJavaClass.isEnum()) {
-					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder, Boolean.TRUE);
+					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder);
 					ApiParam param = ApiParam.of()
 						.setField(paramName)
 						.setDesc(comment + ",[array of enum]")
@@ -560,7 +560,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 			// param is enum
 			else if (javaClass.isEnum()) {
 				String o = JavaClassUtil.getEnumParams(javaClass);
-				Object value = JavaClassUtil.getEnumValue(javaClass, builder, true);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder);
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
 					.setId(paramList.size() + 1)
@@ -664,7 +664,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 							|| JakartaJaxrsAnnotations.JAXB_REST_PATH_FULLY.equals(annotationName)
 							|| JAXRSAnnotations.JAX_PATH_PARAM_FULLY.equals(annotationName)) {
 						if (javaClass.isEnum()) {
-							Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
+							Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
 							mockValue = StringUtil.removeQuotes(String.valueOf(value));
 						}
 						pathParamsMap.put(paramName, mockValue);
@@ -715,7 +715,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 					}
 					else if (javaClass.isEnum()) {
 						// do nothing
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.TRUE);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
 						String strVal = StringUtil.removeQuotes(String.valueOf(value));
 						FormData formData = new FormData();
 						formData.setDescription(comment);

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -91,7 +91,7 @@ public class ParamUtil {
 				javaField.getType().getGenericFullyQualifiedName())) {
 			param.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 		}
-		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder, !jsonRequest);
+		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder);
 		if (Objects.nonNull(enumInfoAndValue)) {
 			param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 				.setEnumInfoAndValues(enumInfoAndValue)

--- a/src/main/resources/default.json
+++ b/src/main/resources/default.json
@@ -11,6 +11,7 @@
   "skipTransientField": true,
   "requestExample": true,
   "responseExample": true,
+  "enumNameExample": false,
   "revisionLogs": [
     {
       "version": "1.0",


### PR DESCRIPTION
Discussion #973

1. Check whether you need to use enumName as the enumeration example value based on the enumNameExample configuration. The default value of enumNameExample is false
2. If enumNameExample is false, determine whether to configure a data dictionary
3. If the enumeration is configured for the numeric dictionary, the code field of the data dictionary is taken as the value
4. If there is no data dictionary, determine whether the enumeration has a '@JsonValue' annotation, and if there is a '@JsonValue' annotation take the enumerated value
5. If there is no '@JsonValue' annotation, the first argument of the enumerated field is the enumerated value by default, and if there is no argument, the enumerated field name is taken

Closes #976