### PR TITLE
feat(doc): 'html', 'adoc', 'doc' should support 'Example' just as 'markdown'

### DIFF
--- a/src/main/resources/template/AllInOne.adoc
+++ b/src/main/resources/template/AllInOne.adoc
@@ -45,14 +45,18 @@ for(doc in api.list){
 
 *Content-Type:* `${doc.contentType}`
 
-<%if(isNotEmpty(doc.headers)){%>
+<%if(isNotEmpty(doc.requestHeaders)){%>
 *Request-headers:*
 
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Header | Type|Required|Description|Since
-${doc.headers}
+|Header | Type|Required|Description|Since|Example
+<%
+for(param in doc.requestHeaders){
+%>
+|${param.name}|${param.type}|${param.required}|${param.desc}|${param.since}|${param.value}
+<%}%>
 |====================
 <%}%>
 
@@ -62,11 +66,11 @@ ${doc.headers}
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.pathParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -77,11 +81,11 @@ for(param in doc.pathParams){
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.queryParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -92,11 +96,11 @@ for(param in doc.queryParams){
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.requestParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -113,11 +117,11 @@ ${doc.requestUsage}
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Field | Type|Description|Since
+|Field | Type|Description|Since|Example
 <%
 for(param in doc.responseParams){
 %>
-|${param.field}|${param.type}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>

--- a/src/main/resources/template/AllInOne.html
+++ b/src/main/resources/template/AllInOne.html
@@ -1,1 +1,438 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0"name="viewport"><meta content="smart-doc"name="generator"><%if(isNotEmpty(projectName)){%><title>${projectName}</title><%}else{%><title>API Reference</title><%}%><link href="font.css"rel="stylesheet"><link href="AllInOne.css?v=${version}"rel="stylesheet"/><%if(isNotEmpty(highlightCssLink)){%><link href="${highlightCssLink}"rel="stylesheet"><%}%><style>.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:${background}}.hljs{padding:0}</style><script src="highlight.min.js"></script><script src="jquery.min.js"></script></head><body class="book toc2 toc-left"><div id="header"><%if(isNotEmpty(projectName)){%><h1>${projectName}</h1><%}%><div class="toc2"id="toc"><div id="book-search-input"><input id="search"placeholder="Type to search"type="text"></div><div id="toctitle"><span>API Reference</span></div><ul class="sectlevel1"id="accordion"><%for(apiGroup in apiDocList){%><%if(!apiDocListOnlyHasDefaultGroup){%><%if(apiGroupLP.first){%><li class="open"><a class="dd"href="#_${apiGroup.order}_${apiGroup.group}">${apiGroup.order}.${htmlEscape(apiGroup.group)}</a><ul class="sectlevel1"><%for(api in apiGroup.childrenApiDocs){%><li class="open"><a class="dd"href="#${api.alias}">${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}</a><ul class="sectlevel2"style="display: block"><%for(doc in api.list){%><li><%if(doc.deprecated){%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%></li><%}%></ul></li><%}%></ul></li><%}else{%><li><a class="dd"href="#_${apiGroup.order}_${apiGroup.group}">${apiGroup.order}.${htmlEscape(apiGroup.group)}</a><ul class="sectlevel1"><%for(api in apiGroup.childrenApiDocs){%><li class="open"><a class="dd"href="#${api.alias}">${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}</a><ul class="sectlevel2"><%for(doc in api.list){%><li><%if(doc.deprecated){%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%></li><%}%></ul></li><%}%></ul></li><%}%><%}else{%><%if(apiGroupLP.first){%><%for(api in apiGroup.childrenApiDocs){%><li class="open"><a class="dd"href="#${api.alias}">${api.order}.${htmlEscape(api.desc)}</a><ul class="sectlevel2"><%for(doc in api.list){%><li><%if(doc.deprecated){%><a href="#${doc.methodId}">${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%></li><%}%></ul></li><%}%><%}else{%><%for(api in apiGroup.childrenApiDocs){%><li><a class="dd"href="#${api.alias}">${api.order}.${htmlEscape(api.desc)}</a><ul class="sectlevel2"><%for(doc in api.list){%><li><%if(doc.deprecated){%><a href="#${doc.methodId}">${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%></li><%}%></ul></li><%}%><%}%><%}%><%}%><%if(isNotEmpty(errorCodeList)){%><li><a href="#_${errorListTitle}">${errorCodeListOrder}.${errorListTitle}</a></li><%}%><%if(isNotEmpty(dictList)){%><li><a class="dd"href="#_${dictListTitle}">${dictListOrder}.${dictListTitle}</a><ul class="sectlevel2"><%for(dict in dictList){%><li><a href="#_${dictListOrder}_${dict.order}_${dict.title}">${dictListOrder}.${dict.order}.${dict.title}</a></li><%}%></ul></li><%}%></ul></div></div><div id="content"><%if(isNotEmpty(revisionLogList)){%><div id="preamble"><div class="sectionbody"><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Version</th><th class="tableblock halign-left valign-top">Update Time</th><th class="tableblock halign-left valign-top">Status</th><th class="tableblock halign-left valign-top">Author</th><th class="tableblock halign-left valign-top">Description</th></tr></thead><tbody><%for(revisionLog in revisionLogList){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.version}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.revisionTime}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.status}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.author}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(revisionLog.remarks)}</p></td></tr><%}%></tbody></table></div></div><%}%><%for(apiGroup in apiDocList){%><%if(!apiDocListOnlyHasDefaultGroup){%><h1 id="_${apiGroup.order}_${apiGroup.name}"><a class="anchor"href="#_${apiGroup.order}_${apiGroup.name}"></a><a class="link"href="#_${apiGroup.order}_${apiGroup.name}">${apiGroup.order}.${htmlEscape(apiGroup.name)}</a></h1><%}%><%for(api in apiGroup.childrenApiDocs){%><div class="sect1"><h2 id="${api.alias}"><a class="anchor"href="#${api.alias}"></a><a class="link"href="#${api.alias}"><%if(apiGroupLP.size>1){%>${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}<%}else{%>${api.order}.${htmlEscape(api.desc)}<%}%></a></h2><div class="sectionbody"><%for(doc in api.list){%><div class="sect2"id="${doc.methodId}"><h3 id="_${apiGroup.order}_${api.order}_${doc.order}_${removeLineBreaks(doc.desc)}"><a class="anchor"href="#${doc.methodId}"></a><%if(doc.deprecated){%><a class="link"href="#${doc.methodId}"><%if(!apiDocListOnlyHasDefaultGroup){%>${apiGroup.order}.${api.order}.${doc.order}.<%}else{%>${api.order}.${doc.order}.<%}%><span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a class="link"href="#${doc.methodId}"><%if(!apiDocListOnlyHasDefaultGroup){%>${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}<%}else{%>${api.order}.${doc.order}.${htmlEscape(doc.desc)}<%}%></a><%}%></h3><div class="paragraph"data-download="${doc.download}"data-page="${doc.page}"data-url="${doc.url}"id="${doc.methodId}-url"><p><strong>URL:</strong><a class="bare"href="${doc.url}">&nbsp;${doc.url}</a></p></div><div class="paragraph"data-method="${doc.type}"id="${doc.methodId}-method"><p><strong>Type:&nbsp;</strong>${doc.type}</p></div><%if(isNotEmpty(doc.author)){%><div class="paragraph"><p><strong>Author:&nbsp;</strong>${doc.author}</p></div><%}%><div class="paragraph"data-content-type="${doc.contentType}"id="${doc.methodId}-content-type"><p><strong>Content-Type:&nbsp;</strong>${doc.contentType}</p></div><div class="paragraph"><p><strong>Description:&nbsp;</strong>${htmlEscape(doc.detail)}</p></div><%if(isNotEmpty(doc.requestHeaders)&&displayRequestParams){%><div class="paragraph"><p><strong>Request-headers:</strong></p></div><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Header</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th><th class="tableblock halign-left valign-top">Required</th><th class="tableblock halign-left valign-top">Since</th></tr></thead><tbody><%for(header in doc.requestHeaders){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${header.name}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${header.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(header.desc)}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${header.required}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${header.since}</p></td></tr><%}%></tbody></table><%}%><%if(isNotEmpty(doc.pathParams)&&displayRequestParams){%><div class="paragraph"><p><strong>Path-parameters:</strong></p></div><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Parameter</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th><th class="tableblock halign-left valign-top">Required</th><th class="tableblock halign-left valign-top">Since</th></tr></thead><tbody><%for(param in doc.pathParams){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td></tr><%}%></tbody></table><%}%><%if(isNotEmpty(doc.queryParams)&&displayRequestParams){%><div class="paragraph"><p><strong>Query-parameters:</strong></p></div><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Parameter</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th><th class="tableblock halign-left valign-top">Required</th><th class="tableblock halign-left valign-top">Since</th></tr></thead><tbody><%for(param in doc.queryParams){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td></tr><%}%></tbody></table><%}%><%if(isNotEmpty(doc.requestParams)&&displayRequestParams){%><div class="paragraph"><p><strong>Body-parameters:</strong></p></div><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"><col style="width: 20%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Parameter</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th><th class="tableblock halign-left valign-top">Required</th><th class="tableblock halign-left valign-top">Since</th></tr></thead><tbody><%for(param in doc.requestParams){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td></tr><%}%></tbody></table><%}%><%if(isNotEmpty(doc.requestUsage)&&isRequestExample){%><div class="paragraph"><p><strong>Request-example:</strong></p></div><div class="listingblock"><div class="content"><pre><code class="bash">${doc.requestUsage}</code></pre></div></div><%}%><%if(isNotEmpty(doc.responseParams)&&displayResponseParams){%><div class="paragraph"><p><strong>Response-fields:</strong></p></div><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 25%;"><col style="width: 25%;"><col style="width: 25%;"><col style="width: 25%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Field</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th><th class="tableblock halign-left valign-top">Since</th></tr></thead><tbody><%for(param in doc.responseParams){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td></tr><%}%></tbody></table><%}%><%if(isNotEmpty(doc.responseUsage)&&isResponseExample){%><div class="paragraph"><p><strong>Response-example:</strong></p></div><div class="listingblock"><div class="content"><pre><code class="json">${doc.responseUsage}</code></pre></div></div><%}%></div><%}%></div></div><%}%><%}%><%if(isNotEmpty(errorCodeList)){%><div class="sect1"><h2 id="_${errorListTitle}"><a class="anchor"href="#_${errorListTitle}"></a><a class="link"href="#_${errorListTitle}">${errorCodeListOrder}.${errorListTitle}</a></h2><div class="sectionbody"><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Error code</th><th class="tableblock halign-left valign-top">Description</th></tr></thead><tbody><%for(error in errorCodeList){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${error.value}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(error.desc)}</p></td></tr><%}%></tbody></table></div></div><%}%><%if(isNotEmpty(dictList)){%><div class="sect1"><h2 id="_${dictListTitle}"><a class="anchor"href="#_${dictListTitle}"></a><a class="link"href="#_dict_list">${dictListOrder}.${dictListTitle}</a></h2><div class="sectionbody"><%for(dict in dictList){%><div class="sect2"><h3 id="_${dictListOrder}_${dict.order}_${dict.title}"><a class="anchor"href="#_${dictListOrder}_${dict.order}_${dict.title}"></a><a class="link"href="#_${dictListOrder}_${dict.order}_${dict.title}">${dictListOrder}.${dict.order}.${htmlEscape(dict.title)}</a></h3><table class="tableblock frame-all grid-all spread"><colgroup><col style="width: 25%;"><colgroup><col style="width: 25%;"><col style="width: 25%;"><col style="width: 25%;"></colgroup><thead><tr><th class="tableblock halign-left valign-top">Name</th><th class="tableblock halign-left valign-top">Code</th><th class="tableblock halign-left valign-top">Type</th><th class="tableblock halign-left valign-top">Description</th></tr></thead><tbody><%for(dataDict in dict.dataDictList){%><tr><td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.name}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.value}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.type}</p></td><td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(dataDict.desc)}</p></td></tr><%}%></tbody></table></div><%}%></div></div><%}%><footer class="page-footer"><span class="copyright">Generated by smart-doc at ${createTime}</span><span class="footer-modification">Suggestions,contact,support and error reporting on<a href="https://gitee.com/smart-doc-team/smart-doc"target="_blank">&nbsp;Gitee&nbsp;</a>or<a href="https://github.com/smart-doc-group/smart-doc.git"target="_blank">&nbsp;Github</a></span></footer><div href="javascript:void(0)"id="toTop"><img id="upArrow"src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAABlUlEQVRIS+2UvUvDQBiH398Rly4udnARwUXs4qAIOigI4iL30dTZ2T9AcNPVvUsXF7uYttdScNDFRRAnB11cFFwKxcXBJTQnJ6lEbRI/CIiY9e6e5/e+9+ZAGX/ImE9/QKCU2jfGbGTQqq4xZgtSyisiKmQgIAAVCCFWAGxnIOhqrdd/xyUrpRZsP40xSwA6AI57vd5eq9W6T6s8tQIppSKi+gDQNREprfVNkiRRwDlfY4xZ+FAIuSOi8Qjw0nEc5XnebZwkViClXA2T5+xhY8xus9ncEUJMAziITN5FEARuXLsGCoQQywBs8uEovJ+Scz7FGDuMSM4cx3E9z+u8r+SDQEq5SEQ1IhoZBE+QnBKRq7V+iEreCDjn84wxCx9NgidITnK5nFutVh/7e14FSqnZIAhqAMY+A4+TADjyfb/Ubref7J4XQXhxNvnEV+AJlbTy+XypUqn4KBaLBZuciCa/A0+opN5oNFz7FpUBbP4EHicxxsyAcz7HGDvvz3nar5+2Ho5wOQwsU5+KNGDa+r8grUP0DBLjtRtNKEliAAAAAElFTkSuQmCC"><span id="upText">Top</span></div></div><script src="search.js?v=${version}"></script><script>$(function(){const Accordion=function(el,multiple){this.el=el||{};this.multiple=multiple||false;const links=this.el.find(".dd");links.on("click",{el:this.el,multiple:this.multiple},this.dropdown)};Accordion.prototype.dropdown=function(e){const $el=e.data.el;const $this=$(this),$next=$this.next();$next.slideToggle();$this.parent().toggleClass("open");if(!e.data.multiple){$el.find(".submenu").not($next).slideUp("20").parent().removeClass("open")}};new Accordion($("#accordion"),false);hljs.highlightAll();$(window).scroll(function(){if($(window).scrollTop()>100){let $toTop=$("#toTop");$toTop.fadeIn(1500);$toTop.hover(function(){$("#upArrow").hide();$("#upText").show()},function(){$("#upArrow").show();$("#upText").hide()})}else{$("#toTop").fadeOut(1500)}});$("#toTop").click(function(){$("body, html").animate({scrollTop:0},1000);return false})});</script></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta content="smart-doc" name="generator">
+  <%if(isNotEmpty(projectName)){%><title>${projectName}</title><%}else{%><title>API Reference</title><%}%>
+  <link href="font.css" rel="stylesheet">
+  <link href="AllInOne.css?v=${version}" rel="stylesheet"/>
+  <%if(isNotEmpty(highlightCssLink)){%>
+  <link href="${highlightCssLink}" rel="stylesheet">
+  <%}%>
+  <style>.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint {
+    background: ${background}
+  }
+
+  .hljs {
+    padding: 0
+  }</style>
+  <script src="highlight.min.js"></script>
+  <script src="jquery.min.js"></script>
+</head>
+<body class="book toc2 toc-left">
+<div id="header"><%if(isNotEmpty(projectName)){%><h1>${projectName}</h1><%}%>
+  <div class="toc2" id="toc">
+    <div id="book-search-input"><input id="search" placeholder="Type to search" type="text"></div>
+    <div id="toctitle"><span>API Reference</span></div>
+    <ul class="sectlevel1" id="accordion"><%for(apiGroup in
+      apiDocList){%><%if(!apiDocListOnlyHasDefaultGroup){%><%if(apiGroupLP.first){%>
+      <li class="open"><a class="dd" href="#_${apiGroup.order}_${apiGroup.group}">${apiGroup.order}.${htmlEscape(apiGroup.group)}</a>
+        <ul class="sectlevel1"><%for(api in apiGroup.childrenApiDocs){%>
+          <li class="open"><a class="dd" href="#${api.alias}">${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}</a>
+            <ul class="sectlevel2" style="display: block"><%for(doc in api.list){%>
+              <li><%if(doc.deprecated){%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.<span
+                  class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%>
+              </li>
+              <%}%>
+            </ul>
+          </li>
+          <%}%>
+        </ul>
+      </li>
+      <%}else{%>
+      <li><a class="dd" href="#_${apiGroup.order}_${apiGroup.group}">${apiGroup.order}.${htmlEscape(apiGroup.group)}</a>
+        <ul class="sectlevel1"><%for(api in apiGroup.childrenApiDocs){%>
+          <li class="open"><a class="dd" href="#${api.alias}">${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}</a>
+            <ul class="sectlevel2"><%for(doc in api.list){%>
+              <li><%if(doc.deprecated){%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.<span
+                  class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a href="#${doc.methodId}">${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%>
+              </li>
+              <%}%>
+            </ul>
+          </li>
+          <%}%>
+        </ul>
+      </li>
+      <%}%><%}else{%><%if(apiGroupLP.first){%><%for(api in apiGroup.childrenApiDocs){%>
+      <li class="open"><a class="dd" href="#${api.alias}">${api.order}.${htmlEscape(api.desc)}</a>
+        <ul class="sectlevel2"><%for(doc in api.list){%>
+          <li><%if(doc.deprecated){%><a href="#${doc.methodId}">${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a
+              href="#${doc.methodId}">${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%>
+          </li>
+          <%}%>
+        </ul>
+      </li>
+      <%}%><%}else{%><%for(api in apiGroup.childrenApiDocs){%>
+      <li><a class="dd" href="#${api.alias}">${api.order}.${htmlEscape(api.desc)}</a>
+        <ul class="sectlevel2"><%for(doc in api.list){%>
+          <li><%if(doc.deprecated){%><a href="#${doc.methodId}">${api.order}.${doc.order}.<span class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a
+              href="#${doc.methodId}">${api.order}.${doc.order}.${htmlEscape(doc.desc)}</a><%}%>
+          </li>
+          <%}%>
+        </ul>
+      </li>
+      <%}%><%}%><%}%><%}%><%if(isNotEmpty(errorCodeList)){%>
+      <li><a href="#_${errorListTitle}">${errorCodeListOrder}.${errorListTitle}</a></li>
+      <%}%><%if(isNotEmpty(dictList)){%>
+      <li><a class="dd" href="#_${dictListTitle}">${dictListOrder}.${dictListTitle}</a>
+        <ul class="sectlevel2"><%for(dict in dictList){%>
+          <li><a href="#_${dictListOrder}_${dict.order}_${dict.title}">${dictListOrder}.${dict.order}.${dict.title}</a>
+          </li>
+          <%}%>
+        </ul>
+      </li>
+      <%}%>
+    </ul>
+  </div>
+</div>
+<div id="content"><%if(isNotEmpty(revisionLogList)){%>
+  <div id="preamble">
+    <div class="sectionbody">
+      <table class="tableblock frame-all grid-all spread">
+        <colgroup>
+          <col style="width: 20%;">
+          <col style="width: 20%;">
+          <col style="width: 20%;">
+          <col style="width: 20%;">
+          <col style="width: 20%;">
+        </colgroup>
+        <thead>
+        <tr>
+          <th class="tableblock halign-left valign-top">Version</th>
+          <th class="tableblock halign-left valign-top">Update Time</th>
+          <th class="tableblock halign-left valign-top">Status</th>
+          <th class="tableblock halign-left valign-top">Author</th>
+          <th class="tableblock halign-left valign-top">Description</th>
+        </tr>
+        </thead>
+        <tbody><%for(revisionLog in revisionLogList){%>
+        <tr>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.version}</p></td>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.revisionTime}</p></td>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.status}</p></td>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${revisionLog.author}</p></td>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(revisionLog.remarks)}</p>
+          </td>
+        </tr>
+        <%}%>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <%}%><%for(apiGroup in apiDocList){%><%if(!apiDocListOnlyHasDefaultGroup){%><h1
+      id="_${apiGroup.order}_${apiGroup.name}"><a class="anchor" href="#_${apiGroup.order}_${apiGroup.name}"></a><a
+      class="link" href="#_${apiGroup.order}_${apiGroup.name}">${apiGroup.order}.${htmlEscape(apiGroup.name)}</a></h1>
+  <%}%><%for(api in apiGroup.childrenApiDocs){%>
+  <div class="sect1"><h2 id="${api.alias}"><a class="anchor" href="#${api.alias}"></a><a class="link"
+                                                                                         href="#${api.alias}"><%if(apiGroupLP.size>1){%>${apiGroup.order}.${api.order}.${htmlEscape(api.desc)}<%}else{%>${api.order}.${htmlEscape(api.desc)}<%}%></a>
+  </h2>
+    <div class="sectionbody"><%for(doc in api.list){%>
+      <div class="sect2" id="${doc.methodId}"><h3
+          id="_${apiGroup.order}_${api.order}_${doc.order}_${removeLineBreaks(doc.desc)}"><a class="anchor"
+                                                                                             href="#${doc.methodId}"></a><%if(doc.deprecated){%><a
+          class="link" href="#${doc.methodId}"><%if(!apiDocListOnlyHasDefaultGroup){%>${apiGroup.order}.${api.order}.${doc.order}.<%}else{%>${api.order}.${doc.order}.<%}%><span
+          class="line-through">${htmlEscape(doc.desc)}</span></a><%}else{%><a class="link" href="#${doc.methodId}"><%if(!apiDocListOnlyHasDefaultGroup){%>${apiGroup.order}.${api.order}.${doc.order}.${htmlEscape(doc.desc)}<%}else{%>${api.order}.${doc.order}.${htmlEscape(doc.desc)}<%}%></a><%}%>
+      </h3>
+        <div class="paragraph" data-download="${doc.download}" data-page="${doc.page}" data-url="${doc.url}"
+             id="${doc.methodId}-url"><p><strong>URL:</strong><a class="bare" href="${doc.url}">&nbsp;${doc.url}</a></p>
+        </div>
+        <div class="paragraph" data-method="${doc.type}" id="${doc.methodId}-method"><p><strong>Type:&nbsp;</strong>${doc.type}
+        </p></div>
+        <%if(isNotEmpty(doc.author)){%>
+        <div class="paragraph"><p><strong>Author:&nbsp;</strong>${doc.author}</p></div>
+        <%}%>
+        <div class="paragraph" data-content-type="${doc.contentType}" id="${doc.methodId}-content-type"><p><strong>Content-Type:&nbsp;</strong>${doc.contentType}
+        </p></div>
+        <div class="paragraph"><p><strong>Description:&nbsp;</strong>${htmlEscape(doc.detail)}</p></div>
+        <%if(isNotEmpty(doc.requestHeaders)&&displayRequestParams){%>
+        <div class="paragraph"><p><strong>Request-headers:</strong></p></div>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Header</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+            <th class="tableblock halign-left valign-top">Required</th>
+            <th class="tableblock halign-left valign-top">Since</th>
+            <th class="tableblock halign-left valign-top">Example</th>
+          </tr>
+          </thead>
+          <tbody><%for(header in doc.requestHeaders){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${header.name}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${header.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(header.desc)}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${header.required}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${header.since}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${header.value}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+        <%}%><%if(isNotEmpty(doc.pathParams)&&displayRequestParams){%>
+        <div class="paragraph"><p><strong>Path-parameters:</strong></p></div>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Parameter</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+            <th class="tableblock halign-left valign-top">Required</th>
+            <th class="tableblock halign-left valign-top">Since</th>
+            <th class="tableblock halign-left valign-top">Example</th>
+          </tr>
+          </thead>
+          <tbody><%for(param in doc.pathParams){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+        <%}%><%if(isNotEmpty(doc.queryParams)&&displayRequestParams){%>
+        <div class="paragraph"><p><strong>Query-parameters:</strong></p></div>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Parameter</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+            <th class="tableblock halign-left valign-top">Required</th>
+            <th class="tableblock halign-left valign-top">Since</th>
+            <th class="tableblock halign-left valign-top">Example</th>
+          </tr>
+          </thead>
+          <tbody><%for(param in doc.queryParams){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+        <%}%><%if(isNotEmpty(doc.requestParams)&&displayRequestParams){%>
+        <div class="paragraph"><p><strong>Body-parameters:</strong></p></div>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+            <col style="width: 20%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Parameter</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+            <th class="tableblock halign-left valign-top">Required</th>
+            <th class="tableblock halign-left valign-top">Since</th>
+            <th class="tableblock halign-left valign-top">Example</th>
+          </tr>
+          </thead>
+          <tbody><%for(param in doc.requestParams){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+        <%}%><%if(isNotEmpty(doc.requestUsage)&&isRequestExample){%>
+        <div class="paragraph"><p><strong>Request-example:</strong></p></div>
+        <div class="listingblock">
+          <div class="content">
+            <pre><code class="bash">${doc.requestUsage}</code></pre>
+          </div>
+        </div>
+        <%}%><%if(isNotEmpty(doc.responseParams)&&displayResponseParams){%>
+        <div class="paragraph"><p><strong>Response-fields:</strong></p></div>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 25%;">
+            <col style="width: 25%;">
+            <col style="width: 25%;">
+            <col style="width: 25%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Field</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+            <th class="tableblock halign-left valign-top">Since</th>
+            <th class="tableblock halign-left valign-top">Example</th>
+          </tr>
+          </thead>
+          <tbody><%for(param in doc.responseParams){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.field}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.desc}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+        <%}%><%if(isNotEmpty(doc.responseUsage)&&isResponseExample){%>
+        <div class="paragraph"><p><strong>Response-example:</strong></p></div>
+        <div class="listingblock">
+          <div class="content">
+            <pre><code class="json">${doc.responseUsage}</code></pre>
+          </div>
+        </div>
+        <%}%>
+      </div>
+      <%}%>
+    </div>
+  </div>
+  <%}%><%}%><%if(isNotEmpty(errorCodeList)){%>
+  <div class="sect1"><h2 id="_${errorListTitle}"><a class="anchor" href="#_${errorListTitle}"></a><a class="link"
+                                                                                                     href="#_${errorListTitle}">${errorCodeListOrder}.${errorListTitle}</a>
+  </h2>
+    <div class="sectionbody">
+      <table class="tableblock frame-all grid-all spread">
+        <colgroup>
+          <col style="width: 50%;">
+          <col style="width: 50%;">
+        </colgroup>
+        <thead>
+        <tr>
+          <th class="tableblock halign-left valign-top">Error code</th>
+          <th class="tableblock halign-left valign-top">Description</th>
+        </tr>
+        </thead>
+        <tbody><%for(error in errorCodeList){%>
+        <tr>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${error.value}</p></td>
+          <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(error.desc)}</p></td>
+        </tr>
+        <%}%>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <%}%><%if(isNotEmpty(dictList)){%>
+  <div class="sect1"><h2 id="_${dictListTitle}"><a class="anchor" href="#_${dictListTitle}"></a><a class="link"
+                                                                                                   href="#_dict_list">${dictListOrder}.${dictListTitle}</a>
+  </h2>
+    <div class="sectionbody"><%for(dict in dictList){%>
+      <div class="sect2"><h3 id="_${dictListOrder}_${dict.order}_${dict.title}"><a class="anchor"
+                                                                                   href="#_${dictListOrder}_${dict.order}_${dict.title}"></a><a
+          class="link" href="#_${dictListOrder}_${dict.order}_${dict.title}">${dictListOrder}.${dict.order}.${htmlEscape(dict.title)}</a>
+      </h3>
+        <table class="tableblock frame-all grid-all spread">
+          <colgroup>
+            <col style="width: 25%;">
+          <colgroup>
+            <col style="width: 25%;">
+            <col style="width: 25%;">
+            <col style="width: 25%;">
+          </colgroup>
+          <thead>
+          <tr>
+            <th class="tableblock halign-left valign-top">Name</th>
+            <th class="tableblock halign-left valign-top">Code</th>
+            <th class="tableblock halign-left valign-top">Type</th>
+            <th class="tableblock halign-left valign-top">Description</th>
+          </tr>
+          </thead>
+          <tbody><%for(dataDict in dict.dataDictList){%>
+          <tr>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.name}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.value}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${dataDict.type}</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(dataDict.desc)}</p></td>
+          </tr>
+          <%}%>
+          </tbody>
+        </table>
+      </div>
+      <%}%>
+    </div>
+  </div>
+  <%}%>
+  <footer class="page-footer"><span class="copyright">Generated by smart-doc at ${createTime}</span><span
+      class="footer-modification">Suggestions,contact,support and error reporting on<a
+      href="https://gitee.com/smart-doc-team/smart-doc" target="_blank">&nbsp;Gitee&nbsp;</a>or<a
+      href="https://github.com/smart-doc-group/smart-doc.git" target="_blank">&nbsp;Github</a></span></footer>
+  <div href="javascript:void(0)" id="toTop"><img id="upArrow"
+                                                 src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAABlUlEQVRIS+2UvUvDQBiH398Rly4udnARwUXs4qAIOigI4iL30dTZ2T9AcNPVvUsXF7uYttdScNDFRRAnB11cFFwKxcXBJTQnJ6lEbRI/CIiY9e6e5/e+9+ZAGX/ImE9/QKCU2jfGbGTQqq4xZgtSyisiKmQgIAAVCCFWAGxnIOhqrdd/xyUrpRZsP40xSwA6AI57vd5eq9W6T6s8tQIppSKi+gDQNREprfVNkiRRwDlfY4xZ+FAIuSOi8Qjw0nEc5XnebZwkViClXA2T5+xhY8xus9ncEUJMAziITN5FEARuXLsGCoQQywBs8uEovJ+Scz7FGDuMSM4cx3E9z+u8r+SDQEq5SEQ1IhoZBE+QnBKRq7V+iEreCDjn84wxCx9NgidITnK5nFutVh/7e14FSqnZIAhqAMY+A4+TADjyfb/Ubref7J4XQXhxNvnEV+AJlbTy+XypUqn4KBaLBZuciCa/A0+opN5oNFz7FpUBbP4EHicxxsyAcz7HGDvvz3nar5+2Ho5wOQwsU5+KNGDa+r8grUP0DBLjtRtNKEliAAAAAElFTkSuQmCC"><span
+      id="upText">Top</span></div>
+</div>
+<script src="search.js?v=${version}"></script>
+<script>$(function () {
+  const Accordion = function (el, multiple) {
+    this.el = el || {};
+    this.multiple = multiple || false;
+    const links = this.el.find(".dd");
+    links.on("click", {el: this.el, multiple: this.multiple}, this.dropdown)
+  };
+  Accordion.prototype.dropdown = function (e) {
+    const $el = e.data.el;
+    const $this = $(this), $next = $this.next();
+    $next.slideToggle();
+    $this.parent().toggleClass("open");
+    if (!e.data.multiple) {
+      $el.find(".submenu").not($next).slideUp("20").parent().removeClass("open")
+    }
+  };
+  new Accordion($("#accordion"), false);
+  hljs.highlightAll();
+  $(window).scroll(function () {
+    if ($(window).scrollTop() > 100) {
+      let $toTop = $("#toTop");
+      $toTop.fadeIn(1500);
+      $toTop.hover(function () {
+        $("#upArrow").hide();
+        $("#upText").show()
+      }, function () {
+        $("#upArrow").show();
+        $("#upText").hide()
+      })
+    } else {
+      $("#toTop").fadeOut(1500)
+    }
+  });
+  $("#toTop").click(function () {
+    $("body, html").animate({scrollTop: 0}, 1000);
+    return false
+  })
+});</script>
+</body>
+</html>

--- a/src/main/resources/template/ApiDoc.adoc
+++ b/src/main/resources/template/ApiDoc.adoc
@@ -20,14 +20,18 @@ for(doc in list){
 
 *Description:* ${doc.detail}
 
-<%if(isNotEmpty(doc.headers)){%>
+<%if(isNotEmpty(doc.requestHeaders)){%>
 *Request-headers:*
 
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Header | Type|Required|Description|Since
-${doc.headers}
+|Header | Type|Required|Description|Since|Example
+<%
+for(param in doc.requestHeaders){
+%>
+|${param.name}|${param.type}|${param.required}|${param.desc}|${param.since}|${param.value}
+<%}%>
 |====================
 <%}%>
 
@@ -38,11 +42,11 @@ ${doc.headers}
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.pathParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -53,11 +57,11 @@ for(param in doc.pathParams){
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.queryParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -68,11 +72,11 @@ for(param in doc.queryParams){
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Parameter | Type|Required|Description|Since
+|Parameter | Type|Required|Description|Since|Example
 <%
 for(param in doc.requestParams){
 %>
-|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.required}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>
@@ -90,11 +94,11 @@ ${doc.requestUsage}
 [width="100%",options="header"]
 [stripes=even]
 |====================
-|Field | Type|Description|Since
+|Field | Type|Description|Since|Example
 <%
 for(param in doc.responseParams){
 %>
-|${param.field}|${param.type}|${param.desc}|${param.version}
+|${param.field}|${param.type}|${param.desc}|${param.version}|${param.value}
 <%}%>
 |====================
 <%}%>

--- a/src/main/resources/template/html/index.html
+++ b/src/main/resources/template/html/index.html
@@ -93,6 +93,7 @@
                         <th class="tableblock halign-left valign-top">Description</th>
                         <th class="tableblock halign-left valign-top">Required</th>
                         <th class="tableblock halign-left valign-top">Since</th>
+                        <th class="tableblock halign-left valign-top">Example</th>
                     </tr>
                     </thead>
                     <tbody><%for(header in doc.requestHeaders){%>
@@ -102,6 +103,7 @@
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(header.desc)}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${header.required}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${header.since}</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${header.value}</p></td>
                     </tr>
                     <%}%>
                     </tbody>
@@ -123,6 +125,7 @@
                         <th class="tableblock halign-left valign-top">Description</th>
                         <th class="tableblock halign-left valign-top">Required</th>
                         <th class="tableblock halign-left valign-top">Since</th>
+                        <th class="tableblock halign-left valign-top">Example</th>
                     </tr>
                     </thead>
                     <tbody><%for(param in doc.pathParams){%>
@@ -132,6 +135,7 @@
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(param.desc)}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
                     </tr>
                     <%}%>
                     </tbody>
@@ -153,6 +157,7 @@
                         <th class="tableblock halign-left valign-top">Description</th>
                         <th class="tableblock halign-left valign-top">Required</th>
                         <th class="tableblock halign-left valign-top">Since</th>
+                        <th class="tableblock halign-left valign-top">Example</th>
                     </tr>
                     </thead>
                     <tbody><%for(param in doc.queryParams){%>
@@ -162,6 +167,7 @@
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(param.desc)}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
                     </tr>
                     <%}%>
                     </tbody>
@@ -183,6 +189,7 @@
                         <th class="tableblock halign-left valign-top">Description</th>
                         <th class="tableblock halign-left valign-top">Required</th>
                         <th class="tableblock halign-left valign-top">Since</th>
+                        <th class="tableblock halign-left valign-top">Example</th>
                     </tr>
                     </thead>
                     <tbody><%for(param in doc.requestParams){%>
@@ -192,6 +199,7 @@
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(param.desc)}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.required}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
                     </tr>
                     <%}%>
                     </tbody>
@@ -218,6 +226,7 @@
                         <th class="tableblock halign-left valign-top">Type</th>
                         <th class="tableblock halign-left valign-top">Description</th>
                         <th class="tableblock halign-left valign-top">Since</th>
+                        <th class="tableblock halign-left valign-top">Example</th>
                     </tr>
                     </thead>
                     <tbody><%for(param in doc.responseParams){%>
@@ -226,6 +235,7 @@
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.type}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${htmlEscape(param.desc)}</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">${param.version}</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">${param.value}</p></td>
                     </tr>
                     <%}%>
                     </tbody>

--- a/src/main/resources/template/word/AllInOneWordTemplate.xml
+++ b/src/main/resources/template/word/AllInOneWordTemplate.xml
@@ -502,7 +502,7 @@
         </w:p>
 
         <!--    请求头    -->
-        <%if(isNotEmpty(doc.headers)){%>
+        <%if(isNotEmpty(doc.requestHeaders)){%>
         <w:p>
             <w:pPr>
                 <w:pStyle w:val="29"/>
@@ -664,6 +664,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(header in doc.requestHeaders){
@@ -781,6 +806,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${header.since}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (headerLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${header.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -952,6 +1000,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.pathParams){
@@ -1069,6 +1142,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -1240,6 +1336,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.queryParams){
@@ -1357,6 +1478,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -1529,6 +1673,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.requestParams){
@@ -1646,6 +1815,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -1826,6 +2018,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.responseParams){
@@ -1917,6 +2134,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>

--- a/src/main/resources/template/word/index.xml
+++ b/src/main/resources/template/word/index.xml
@@ -173,7 +173,7 @@
         </w:p>
 
         <!--    请求头    -->
-        <%if(isNotEmpty(doc.headers)){%>
+        <%if(isNotEmpty(doc.requestHeaders)){%>
         <w:p>
             <w:pPr>
                 <w:pStyle w:val="29"/>
@@ -335,6 +335,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(header in doc.requestHeaders){
@@ -452,6 +477,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${header.since}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (headerLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${header.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -623,6 +671,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.pathParams){
@@ -740,6 +813,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -911,6 +1007,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.queryParams){
@@ -1028,6 +1149,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -1200,6 +1344,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.requestParams){
@@ -1317,6 +1486,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>
@@ -1497,6 +1689,31 @@
                         </w:r>
                     </w:p>
                 </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:rPr>
+                                <w:b/>
+                                <w:bCs/>
+                            </w:rPr>
+                            <w:t>Example</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
             </w:tr>
             <%
             for(param in doc.responseParams){
@@ -1588,6 +1805,29 @@
                         </w:pPr>
                         <w:r>
                             <w:t>${param.version}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:tcPr>
+                        <w:tcW w:w="2700" w:type="dxa"/>
+                        <w:tcBorders>
+                            <w:top w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:left w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:bottom w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                            <w:right w:val="single" w:color="DFE2E5" w:sz="4" w:space="0"/>
+                        </w:tcBorders>
+                        <%if (paramLP.index % 2 == 0) {%>
+                        <w:shd w:val="clear" w:color="auto" w:fill="F8F8F8"/>
+                        <%}%>
+                    </w:tcPr>
+                    <w:p>
+                        <w:pPr>
+                            <w:pStyle w:val="24"/>
+                            <w:jc w:val="left"/>
+                        </w:pPr>
+                        <w:r>
+                            <w:t>${param.value}</w:t>
                         </w:r>
                     </w:p>
                 </w:tc>


### PR DESCRIPTION
1. 'html' document support 'Example' fields
2. 'adoc' document support 'Example' fields
3. 'doc' document support 'Example' fields
4. Fix the adoc document request header parameters are incorrect

Closes #984