### PR TITLE
feat: bump qdox to 2.0.3.5 and support jdk17 text block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <beetl.version>3.17.0.RELEASE</beetl.version>
         <common-util.version>2.2.7</common-util.version>
-        <qdox.version>2.0.3.4</qdox.version>
+        <qdox.version>2.0.3.5</qdox.version>
         <datafaker.version>1.4.0</datafaker.version>
         <gson.version>2.11.0</gson.version>
         <eclipse.jgit.version>5.13.3.202401111512-r</eclipse.jgit.version>


### PR DESCRIPTION
fix #589 