### PR TITLE
perf(enum): Added the 'enumConvertor' configuration and modified the enumeration example value logic

### DIFF
--- a/src/main/java/com/ly/doc/handler/IHeaderHandler.java
+++ b/src/main/java/com/ly/doc/handler/IHeaderHandler.java
@@ -140,7 +140,8 @@ public interface IHeaderHandler {
 				apiReqHeader.setDesc(apiReqHeader.getDesc() + enumComment);
 				apiReqHeader.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
 
-				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder);
+				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder,
+						Boolean.FALSE);
 				if (Objects.nonNull(enumInfoAndValue)) {
 					String enumValue = StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue()));
 					apiReqHeader.setValue(enumValue + "," + enumValue).setEnumInfoAndValues(enumInfoAndValue);
@@ -173,7 +174,7 @@ public interface IHeaderHandler {
 			apiReqHeader.setDesc(apiReqHeader.getDesc() + enumComment);
 			apiReqHeader.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 
-			EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder);
+			EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder, Boolean.FALSE);
 			if (Objects.nonNull(enumInfoAndValue)) {
 				String enumValue = StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue()));
 				apiReqHeader.setValue(enumValue)

--- a/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/FormDataBuildHelper.java
@@ -174,7 +174,7 @@ public class FormDataBuildHelper extends BaseHelper {
 				formDataList.add(formData);
 			}
 			else if (javaClass.isEnum()) {
-				Object value = JavaClassUtil.getEnumValue(javaClass, builder);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
 				if (tagsMap.containsKey(DocTags.MOCK) && StringUtil.isNotEmpty(tagsMap.get(DocTags.MOCK))) {
 					value = ParamUtil.formatMockValue(tagsMap.get(DocTags.MOCK));
 				}

--- a/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/JsonBuildHelper.java
@@ -60,7 +60,8 @@ public class JsonBuildHelper extends BaseHelper {
 			return "File download.";
 		}
 		if (method.getReturns().isEnum() && Objects.isNull(responseBodyAdvice)) {
-			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), builder)));
+			return StringUtil
+				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(method.getReturns(), builder, Boolean.TRUE)));
 		}
 		if (method.getReturns().isPrimitive() && Objects.isNull(responseBodyAdvice)) {
 			String typeName = method.getReturnType().getCanonicalName();
@@ -157,7 +158,8 @@ public class JsonBuildHelper extends BaseHelper {
 
 		// Handle enum types
 		if (javaClass.isEnum()) {
-			return StringUtil.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, projectBuilder)));
+			return StringUtil
+				.removeQuotes(String.valueOf(JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.TRUE)));
 		}
 
 		StringBuilder result = new StringBuilder();
@@ -387,7 +389,8 @@ public class JsonBuildHelper extends BaseHelper {
 								JavaClass arraySubClass = projectBuilder.getJavaProjectBuilder()
 									.getClassByName(gicName);
 								if (arraySubClass.isEnum()) {
-									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder);
+									Object value = JavaClassUtil.getEnumValue(arraySubClass, projectBuilder,
+											Boolean.TRUE);
 									result.append("[").append(value).append("],");
 									continue;
 								}
@@ -460,7 +463,7 @@ public class JsonBuildHelper extends BaseHelper {
 							// if has Annotation @JsonSerialize And using
 							// ToStringSerializer && isResp
 							else if (toStringSerializer && isResp) {
-								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.TRUE);
 								result.append(value).append(",");
 							}
 							// if has @JsonFormat
@@ -468,7 +471,7 @@ public class JsonBuildHelper extends BaseHelper {
 								result.append(fieldJsonFormatValue).append(",");
 							}
 							else {
-								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder);
+								Object value = JavaClassUtil.getEnumValue(javaClass, projectBuilder, Boolean.TRUE);
 								result.append(value).append(",");
 							}
 						}

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -505,7 +505,7 @@ public class ParamsBuildHelper extends BaseHelper {
 								param.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
 
 								EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(arraySubClass,
-										projectBuilder);
+										projectBuilder, Boolean.TRUE);
 								if (Objects.nonNull(enumInfoAndValue)) {
 									param.setValue("[" + enumInfoAndValue.getValue() + "]")
 										.setEnumInfoAndValues(enumInfoAndValue);

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -458,11 +458,14 @@ public class ApiConfig {
 	private boolean addDefaultHttpStatuses;
 
 	/**
-	 * Show enum name for example
+	 * Whether to enable the enumeration converter, The default value is false. If true,
+	 * the enumeration value is parsed as an enumeration example value in the
+	 * header/path/query request mode. If false, take the enumeration name as the
+	 * enumeration example value
 	 *
 	 * @since 3.1.0
 	 */
-	private boolean enumNameExample = Boolean.FALSE;
+	private boolean enumConvertor = Boolean.FALSE;
 
 	public static ApiConfig getInstance() {
 		return instance;
@@ -1145,12 +1148,12 @@ public class ApiConfig {
 		this.addDefaultHttpStatuses = addDefaultHttpStatuses;
 	}
 
-	public boolean isEnumNameExample() {
-		return enumNameExample;
+	public boolean isEnumConvertor() {
+		return enumConvertor;
 	}
 
-	public void setEnumNameExample(boolean enumNameExample) {
-		this.enumNameExample = enumNameExample;
+	public void setEnumConvertor(boolean enumConvertor) {
+		this.enumConvertor = enumConvertor;
 	}
 
 }

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1167,7 +1167,8 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 						.setQueryParam(isQueryParam)
 						.setId(paramList.size() + 1)
 						.setType(ParamTypeConstants.PARAM_TYPE_ARRAY);
-					EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder);
+					EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(gicJavaClass, builder,
+							Boolean.FALSE);
 					if (Objects.nonNull(enumInfoAndValue)) {
 						param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 							.setEnumInfoAndValues(enumInfoAndValue);
@@ -1275,7 +1276,8 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.setRequired(required)
 					.setVersion(DocGlobalConstants.DEFAULT_VERSION);
 
-				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder);
+				EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(javaClass, builder,
+						ApiParamEnum.BODY.equals(apiParamEnum));
 				if (Objects.nonNull(enumInfoAndValue)) {
 					param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 						.setEnumInfoAndValues(enumInfoAndValue)
@@ -1472,7 +1474,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.FALSE);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (pathParamsMap.containsKey(paramName)) {
@@ -1486,7 +1488,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					.getAnnotationName()
 					.contains(annotationName)) {
 					if (javaClass.isEnum()) {
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.FALSE);
 						mockValue = StringUtil.removeQuotes(String.valueOf(value));
 					}
 					if (queryParamsMap.containsKey(paramName)) {
@@ -1563,7 +1565,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				String value;
 				JavaClass javaClass1 = configBuilder.getClassByName(gicName);
 				if (Objects.nonNull(javaClass1) && javaClass1.isEnum()) {
-					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, configBuilder));
+					value = String.valueOf(JavaClassUtil.getEnumValue(javaClass1, configBuilder, Boolean.FALSE));
 				}
 				else {
 					value = RandomUtil.randomValueByType(gicName);
@@ -1581,7 +1583,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 			// enum type
 			else if (javaClass.isEnum()) {
 				// do nothing
-				Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
+				Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.FALSE);
 				String strVal = StringUtil.removeQuotes(String.valueOf(value));
 				FormData formData = new FormData();
 				formData.setKey(paramName);

--- a/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/JAXRSDocBuildTemplate.java
@@ -450,7 +450,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 				}
 				JavaClass gicJavaClass = builder.getJavaProjectBuilder().getClassByName(gicName);
 				if (gicJavaClass.isEnum()) {
-					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder);
+					Object value = JavaClassUtil.getEnumValue(gicJavaClass, builder, Boolean.FALSE);
 					ApiParam param = ApiParam.of()
 						.setField(paramName)
 						.setDesc(comment + ",[array of enum]")
@@ -560,7 +560,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 			// param is enum
 			else if (javaClass.isEnum()) {
 				String o = JavaClassUtil.getEnumParams(javaClass);
-				Object value = JavaClassUtil.getEnumValue(javaClass, builder);
+				Object value = JavaClassUtil.getEnumValue(javaClass, builder, Boolean.FALSE);
 				ApiParam param = ApiParam.of()
 					.setField(paramName)
 					.setId(paramList.size() + 1)
@@ -664,7 +664,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 							|| JakartaJaxrsAnnotations.JAXB_REST_PATH_FULLY.equals(annotationName)
 							|| JAXRSAnnotations.JAX_PATH_PARAM_FULLY.equals(annotationName)) {
 						if (javaClass.isEnum()) {
-							Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
+							Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.FALSE);
 							mockValue = StringUtil.removeQuotes(String.valueOf(value));
 						}
 						pathParamsMap.put(paramName, mockValue);
@@ -715,7 +715,7 @@ public class JAXRSDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IWebSoc
 					}
 					else if (javaClass.isEnum()) {
 						// do nothing
-						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder);
+						Object value = JavaClassUtil.getEnumValue(javaClass, configBuilder, Boolean.FALSE);
 						String strVal = StringUtil.removeQuotes(String.valueOf(value));
 						FormData formData = new FormData();
 						formData.setDescription(comment);

--- a/src/main/java/com/ly/doc/utils/ParamUtil.java
+++ b/src/main/java/com/ly/doc/utils/ParamUtil.java
@@ -91,7 +91,7 @@ public class ParamUtil {
 				javaField.getType().getGenericFullyQualifiedName())) {
 			param.setType(ParamTypeConstants.PARAM_TYPE_ENUM);
 		}
-		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder);
+		EnumInfoAndValues enumInfoAndValue = JavaClassUtil.getEnumInfoAndValue(seeEnum, builder, jsonRequest);
 		if (Objects.nonNull(enumInfoAndValue)) {
 			param.setValue(StringUtil.removeDoubleQuotes(String.valueOf(enumInfoAndValue.getValue())))
 				.setEnumInfoAndValues(enumInfoAndValue)

--- a/src/main/resources/default.json
+++ b/src/main/resources/default.json
@@ -11,7 +11,7 @@
   "skipTransientField": true,
   "requestExample": true,
   "responseExample": true,
-  "enumNameExample": false,
+  "enumConvertor": false,
   "revisionLogs": [
     {
       "version": "1.0",


### PR DESCRIPTION
Added the 'enumConvertor' configuration and modified the enumeration example value logic

```text
1. Added the 'enumConvertor' configuration
2. non-JSON parameters (header/get/path request, post/put request formdata mode)
	1.1. if the 'enumConvertor' configuration is true
		a. If there is '@JsonValue' annotation, take enumeration value according to '@JsonValue' annotation, the parameter type is the actual type of the enumeration value
		b. If there is no '@JsonValue' annotation, take the enumeration name, the parameter type is enum
	1.2. If 'enumConvertor' configuration is false
		Take enumeration name, the parameter type is enum

3. json parameters or json response (post/put request body mode)
	2.1. if there is '@JsonValue' annotation, take the enumeration value according to '@JsonValue' annotation, the parameter type is the actual type of the enumeration value
	2.2. if there is no '@JsonValue' annotation, take the enumeration name, the parameter type is enum
```

#977
#973

Closes #986