### PR TITLE
Fix the request parameter is Map<Enum, Value> is not parsed correctly

### DIFF
--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -707,6 +707,12 @@ public class ParamsBuildHelper extends BaseHelper {
 										.orElse(DocGlobalConstants.DEFAULT_MAP_KEY_DESC))
 					.setVersion(DocGlobalConstants.DEFAULT_VERSION)
 					.setPid(null == keyParentId ? pid : keyParentId);
+
+				Object enumValueWithJsonValue = JavaClassUtil.getEnumValueWithJsonValue(mapKeyClass, projectBuilder,
+						enumConstant);
+				if (jsonRequest && enumValueWithJsonValue != null) {
+					apiParam.setField(pre + enumValueWithJsonValue);
+				}
 				apiParam.setId(apiParam.getPid() + paramList.size() + 1);
 				if (null == keyParentId) {
 					keyParentId = apiParam.getPid();

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1247,7 +1247,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 
 				paramList.addAll(ParamsBuildHelper.buildMapParam(gicNameArr, DocGlobalConstants.EMPTY, 0,
 						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
-						docJavaMethod.getJsonViewClasses(), 0, Boolean.FALSE, 1, null));
+						docJavaMethod.getJsonViewClasses(), 0, jsonRequest, 1, null));
 
 				// is map without Gic
 				if (JavaClassValidateUtil.isMap(typeName)) {

--- a/src/main/java/com/ly/doc/utils/JavaClassUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassUtil.java
@@ -408,7 +408,7 @@ public class JavaClassUtil {
 	 * @return Object The enum value, whose type depends on the specific enum definition
 	 * @throws RuntimeException If the enum constants do not exist
 	 */
-	private static Object getEnumValueWithJsonValue(JavaClass javaClass, ProjectDocConfigBuilder builder,
+	public static Object getEnumValueWithJsonValue(JavaClass javaClass, ProjectDocConfigBuilder builder,
 			JavaField enumConstant) {
 		String methodName = findMethodWithJsonValue(javaClass);
 		if (Objects.nonNull(methodName)) {


### PR DESCRIPTION
1. The repair request parameter is Map<Enum, Value>, and enum is not parsed according to the @JsonValue configuration
2. Fix jsonRequest transfer error

Closes #1002