### PR TITLE
fix(map): Fix the response result is Map<Enum, Value> is not parsed correctly

### DIFF
--- a/src/main/java/com/ly/doc/builder/ProjectDocConfigBuilder.java
+++ b/src/main/java/com/ly/doc/builder/ProjectDocConfigBuilder.java
@@ -214,16 +214,19 @@ public class ProjectDocConfigBuilder {
 	 */
 	public JavaClass getClassByName(String simpleName) {
 		JavaClass cls = javaProjectBuilder.getClassByName(simpleName);
-		List<DocJavaField> fieldList = JavaClassUtil.getFields(cls, 0, new LinkedHashMap<>(), null);
-		// handle inner class
-		if (Objects.isNull(cls.getFields()) || fieldList.isEmpty()) {
-			cls = classFilesMap.get(simpleName);
-		}
-		else {
-			List<JavaClass> classList = cls.getNestedClasses();
-			for (JavaClass javaClass : classList) {
-				classFilesMap.put(javaClass.getFullyQualifiedName(), javaClass);
+
+		if (!cls.isEnum()) {
+			List<DocJavaField> fieldList = JavaClassUtil.getFields(cls, 0, new LinkedHashMap<>(), null);
+			// handle inner class
+			if (Objects.isNull(cls.getFields()) || fieldList.isEmpty()) {
+				cls = classFilesMap.get(simpleName);
+				return cls;
 			}
+		}
+
+		List<JavaClass> classList = cls.getNestedClasses();
+		for (JavaClass javaClass : classList) {
+			classFilesMap.put(javaClass.getFullyQualifiedName(), javaClass);
 		}
 		return cls;
 	}

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -687,7 +687,7 @@ public class ParamsBuildHelper extends BaseHelper {
 		String mapKeySimpleName = DocClassUtil.getSimpleName(globGicName[0]);
 		String valueSimpleName = DocClassUtil.getSimpleName(globGicName[1]);
 		// get map key class
-		JavaClass mapKeyClass = projectBuilder.getJavaProjectBuilder().getClassByName(mapKeySimpleName);
+		JavaClass mapKeyClass = projectBuilder.getClassByName(mapKeySimpleName);
 
 		boolean isShowJavaType = projectBuilder.getApiConfig().getShowJavaType();
 		String valueSimpleNameType = processFieldTypeName(isShowJavaType, valueSimpleName);
@@ -710,7 +710,7 @@ public class ParamsBuildHelper extends BaseHelper {
 
 				Object enumValueWithJsonValue = JavaClassUtil.getEnumValueWithJsonValue(mapKeyClass, projectBuilder,
 						enumConstant);
-				if (jsonRequest && enumValueWithJsonValue != null) {
+				if ((isResp || jsonRequest) && enumValueWithJsonValue != null) {
 					apiParam.setField(pre + enumValueWithJsonValue);
 				}
 				apiParam.setId(apiParam.getPid() + paramList.size() + 1);


### PR DESCRIPTION
1. Modify the 'com.ly.doc.builder.ProjectDocConfigBuilder#getClassByName' logic method, because the enumeration list of fields always returns null
2. Map params modifies the getClassName method
3. Enumeration parameter adds isResponse judgment

Closes #1004