### PR TITLE
refactor(doc): :art: improve API documentation generation and enforce strict `Javadoc` validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,30 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <!--
+                    Fail the build if any Javadoc warnings or errors occur.
+                    This ensures that all Javadoc issues are treated seriously.
+                    -->
+                    <failOnError>true</failOnError>
+                    <additionalOptions>
+                        <!--
+                        Enable strict validation of Javadoc content.
+                        The "all" option checks for syntax, references, and HTML issues.
+                        -->
+                        <additionalOption>-Xdoclint:all</additionalOption>
+                    </additionalOptions>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>validate-javadoc</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>package-javadoc-jar</id>
                         <phase>package</phase>
                         <goals>
                             <goal>jar</goal>

--- a/src/main/java/com/ly/doc/builder/IRpcDocBuilderTemplate.java
+++ b/src/main/java/com/ly/doc/builder/IRpcDocBuilderTemplate.java
@@ -130,6 +130,7 @@ public interface IRpcDocBuilderTemplate<T extends AbstractRpcApiDoc<?>> extends 
 	 * @param javaProjectBuilder JavaProjectBuilder
 	 * @param template template
 	 * @param outPutFileName output file
+	 * @return beetl Template
 	 */
 	default Template buildAllInOneWord(List<RpcApiDoc> apiDocList, ApiConfig config,
 			JavaProjectBuilder javaProjectBuilder, String template, String outPutFileName) {

--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1214,7 +1214,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 					paramList.add(param);
 				}
 				else {
-					if (requestBodyCounter > 0 || !ApiParamEnum.QUERY.equals(apiParamEnum)) {
+					if (requestBodyCounter > 0 || !isQueryParam) {
 						// for json
 						paramList.addAll(ParamsBuildHelper.buildParams(gicNameArr[0], DocGlobalConstants.EMPTY, 0,
 								String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
@@ -1305,6 +1305,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
 						docJavaMethod.getJsonViewClasses(), 1, jsonRequest, null));
 			}
+			// other types
 			else {
 				List<ApiParam> apiParams = ParamsBuildHelper.buildParams(typeName, DocGlobalConstants.EMPTY, 0,
 						String.valueOf(required), Boolean.FALSE, new HashMap<>(16), builder, groupClasses,
@@ -1313,7 +1314,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				boolean hasFile = apiParams.stream()
 					.anyMatch(param -> ParamTypeConstants.PARAM_TYPE_FILE.equals(param.getType()));
 				// if it does not have file and query param, set query param true
-				if (!hasFile && ApiParamEnum.QUERY.equals(apiParamEnum)) {
+				if (!hasFile && isQueryParam) {
 					for (ApiParam apiParam : apiParams) {
 						apiParam.traverseAndConsume(ApiParam::setQueryParamTrue);
 					}


### PR DESCRIPTION
- Update API parameter handling for query parameters
- Add strict `Javadoc` validation in Maven build process
- Refactor RPC documentation building template