### PR TITLE
feat(utils): :sparkles: add functionality to resolve annotation values and get parameter max length

### DIFF
--- a/src/main/java/com/ly/doc/utils/DocUtil.java
+++ b/src/main/java/com/ly/doc/utils/DocUtil.java
@@ -21,15 +21,44 @@
 package com.ly.doc.utils;
 
 import com.ly.doc.builder.WordDocBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.JAXRSAnnotations;
+import com.ly.doc.constants.JakartaJaxrsAnnotations;
+import com.ly.doc.constants.JavaTypeConstants;
+import com.ly.doc.constants.MediaType;
 import com.ly.doc.extension.dict.DictionaryValuesResolver;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDataDictionary;
+import com.ly.doc.model.ApiDocDict;
+import com.ly.doc.model.ApiErrorCode;
+import com.ly.doc.model.ApiErrorCodeDictionary;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.DataDict;
+import com.ly.doc.model.DocJavaField;
+import com.ly.doc.model.FormData;
+import com.ly.doc.model.SystemPlaceholders;
 import com.ly.doc.model.request.RequestMapping;
 import com.mifmif.common.regex.Generex;
-import com.power.common.util.*;
+import com.power.common.util.CollectionUtil;
+import com.power.common.util.DateTimeUtil;
+import com.power.common.util.EnumUtil;
+import com.power.common.util.IDCardUtil;
+import com.power.common.util.RandomUtil;
+import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
-import com.thoughtworks.qdox.model.*;
-import com.thoughtworks.qdox.model.expression.*;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+import com.thoughtworks.qdox.model.JavaMember;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.expression.Add;
+import com.thoughtworks.qdox.model.expression.AnnotationValue;
+import com.thoughtworks.qdox.model.expression.Constant;
+import com.thoughtworks.qdox.model.expression.Expression;
+import com.thoughtworks.qdox.model.expression.FieldRef;
 import net.datafaker.Faker;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -39,9 +68,35 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1004,6 +1059,18 @@ public class DocUtil {
 			.map(Object::toString)
 			.orElse(StringUtil.EMPTY);
 
+	}
+
+	/**
+	 * resolve the string of {@link Add} which has {@link FieldRef}(to be exact is
+	 * {@link FieldRef}) children, the value of {@link FieldRef} will be resolved with the
+	 * real value of it if it is the static final member of any other class
+	 * @param annotationValue annotationValue
+	 * @return annotation value
+	 */
+	public static String resolveAnnotationValue(AnnotationValue annotationValue) {
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		return resolveAnnotationValue(classLoader, annotationValue);
 	}
 
 	/**

--- a/src/main/java/com/ly/doc/utils/JavaFieldUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaFieldUtil.java
@@ -150,6 +150,16 @@ public class JavaFieldUtil {
 	}
 
 	/**
+	 * get param max length
+	 * @param annotations annotation
+	 * @return max length
+	 */
+	public static String getParamMaxLength(List<JavaAnnotation> annotations) {
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		return getParamMaxLength(classLoader, annotations);
+	}
+
+	/**
 	 * Get JSR 303 validation comments.
 	 * @param showValidation Whether to show JSR validation information
 	 * @param classLoader The ClassLoader used to resolve annotation values


### PR DESCRIPTION
- Add resolveAnnotationValue method to resolve the value of annotations with static final members
- Implement getParamMaxLength method to get the maximum length of a parameter from annotations
- Update imports in DocUtil and JavaFieldUtil to support new functionality