### PR TITLE
feat: refactor WordXmlEscape and HtmlEscape

### DIFF
--- a/src/main/java/com/ly/doc/function/HtmlEscape.java
+++ b/src/main/java/com/ly/doc/function/HtmlEscape.java
@@ -25,19 +25,47 @@ import com.ly.doc.utils.DocUtil;
 import org.beetl.core.Context;
 import org.beetl.core.Function;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * beetl template function
+ * Function to escape HTML content in Beetl templates.
+ * <p>
+ * This class provides a method to replace specific HTML characters with their
+ * corresponding escape sequences and clean up comments.
+ * <p>
+ * For example, it replaces:
+ * <p>
+ * - <code>"</code> with <code>&amp;quot;</code>
  *
- * @author yu 2021/6/26.
+ * @author yu
+ * @since 2021/6/26
  */
 public class HtmlEscape implements Function {
 
+	/**
+	 * Map to hold HTML escape sequences.
+	 */
+	private static final Map<String, String> HTML_ESCAPE_MAP;
+
+	static {
+		HTML_ESCAPE_MAP = new HashMap<>();
+		HTML_ESCAPE_MAP.put("<p>", "");
+		HTML_ESCAPE_MAP.put("</p>", " ");
+	}
+
 	@Override
-	public String call(Object[] paras, Context ctx) {
-		String str = String.valueOf(paras[0]).replaceAll("&", "&amp;");
-		str = str.replaceAll("\"", "&quot;");
-		str = str.replaceAll("<p>", "").replaceAll("</p>", " ");
-		return DocUtil.replaceNewLineToHtmlBr(DocUtil.getEscapeAndCleanComment(str));
+	public String call(Object[] params, Context ctx) {
+		if (params == null || params.length == 0 || params[0] == null) {
+			return "";
+		}
+		String html = String.valueOf(params[0]);
+		for (Map.Entry<String, String> entry : HTML_ESCAPE_MAP.entrySet()) {
+			html = html.replace(entry.getKey(), entry.getValue());
+		}
+
+		html = DocUtil.getEscapeAndCleanComment(html);
+		return DocUtil.replaceNewLineToHtmlBr(html);
 	}
 
 }

--- a/src/main/java/com/ly/doc/function/WordXmlEscape.java
+++ b/src/main/java/com/ly/doc/function/WordXmlEscape.java
@@ -20,27 +20,50 @@
  */
 package com.ly.doc.function;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.ly.doc.utils.DocUtil;
 import org.beetl.core.Context;
 import org.beetl.core.Function;
 
 /**
- * beetl template function
+ * Function to escape XML content in Beetl templates.
+ * <p>
+ * For example, it replaces: - <code>" "</code> with <code> </code>
  *
  * @author yu 2021/6/26.
  */
 public class WordXmlEscape implements Function {
 
+	/*
+	 * Represents a non-breaking space character (U+00A0) commonly used in Word documents.
+	 * In HTML, this character is typically represented as "&nbsp;".
+	 */
+	private static final String UNICODE_NON_BREAK_SPACE = "\u00A0";
+
+	private static final Map<String, String> XML_ESCAPE_MAP;
+
+	static {
+		XML_ESCAPE_MAP = new LinkedHashMap<>();
+		XML_ESCAPE_MAP.put(" ", UNICODE_NON_BREAK_SPACE);
+		XML_ESCAPE_MAP.put("&nbsp;&nbsp;", UNICODE_NON_BREAK_SPACE);
+		XML_ESCAPE_MAP.put("&nbsp;", "");
+		XML_ESCAPE_MAP.put("<br/>", "");
+	}
+
 	@Override
-	public String call(Object[] paras, Context ctx) {
-		String str = String.valueOf(paras[0])
-			.replaceAll(" ", " ")
-			.replaceAll("&nbsp;&nbsp;", " ")
-			.replaceAll("&nbsp;", "")
-			.replaceAll("<br/>", "")
-			.replaceAll("&", "&amp;")
-			.replaceAll("<", "&lt;");
-		return DocUtil.getEscapeAndCleanComment(str);
+	public String call(Object[] params, Context ctx) {
+		if (params == null || params.length == 0 || params[0] == null) {
+			return "";
+		}
+
+		String xml = String.valueOf(params[0]);
+		for (Map.Entry<String, String> entry : XML_ESCAPE_MAP.entrySet()) {
+			xml = xml.replaceAll(entry.getKey(), entry.getValue());
+		}
+
+		return DocUtil.getEscapeAndCleanComment(xml);
 	}
 
 }

--- a/src/test/java/com/ly/doc/function/HtmlEscapeTest.java
+++ b/src/test/java/com/ly/doc/function/HtmlEscapeTest.java
@@ -1,0 +1,51 @@
+package com.ly.doc.function;
+
+import org.beetl.core.Context;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HtmlEscapeTest {
+
+	/*
+	 * Since context is not used in the function, we can set it to null.
+	 */
+	private static final Context context = null;
+
+	@ParameterizedTest
+	@MethodSource("provideNormalTestCases")
+	void testHtmlEscape(String input, String expected) {
+		HtmlEscape htmlEscape = new HtmlEscape();
+
+		String result = htmlEscape.call(new Object[] { input }, context);
+
+		assertEquals(expected, result);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void testHtmlEscapeNullAndEmptyString(Object[] input) {
+		HtmlEscape htmlEscape = new HtmlEscape();
+
+		String result = htmlEscape.call(input, context);
+
+		assertEquals("", result);
+	}
+
+	/**
+	 * Provides test cases for normal inputs.
+	 * @return a stream of arguments for testing
+	 */
+	static Stream<Arguments> provideNormalTestCases() {
+		return Stream.of(Arguments.of("&", "&amp;"), Arguments.of("\"", "&quot;"), Arguments.of("<p>", ""),
+				Arguments.of("<p>ab</p>abc", "ab abc"), Arguments.of("</p>", ""),
+				Arguments.of("<p>Hello & \"World\"</p>", "Hello &amp; &quot;World&quot; "), Arguments.of("", ""),
+				Arguments.of(null, ""));
+	}
+
+}

--- a/src/test/java/com/ly/doc/function/WordXmlEscapeTest.java
+++ b/src/test/java/com/ly/doc/function/WordXmlEscapeTest.java
@@ -1,0 +1,55 @@
+package com.ly.doc.function;
+
+import org.beetl.core.Context;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WordXmlEscapeTest {
+
+	private static final String UNICODE_NON_BREAK_SPACE = "\u00A0";
+
+	private static Context context;
+
+	@ParameterizedTest
+	@MethodSource("provideNormalTestCases")
+	void testWordXmlEscape(String input, String expected) {
+		WordXmlEscape wordXmlEscape = new WordXmlEscape();
+
+		String result = wordXmlEscape.call(new Object[] { input }, context);
+
+		assertEquals(expected, result);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void testWordXmlEscapeNullAndEmptyString(Object[] input) {
+		WordXmlEscape wordXmlEscape = new WordXmlEscape();
+
+		String result = wordXmlEscape.call(input, context);
+
+		assertEquals("", result);
+	}
+
+	/**
+	 * Provides test cases for normal inputs.
+	 * @return a stream of arguments for testing
+	 */
+	static Stream<Arguments> provideNormalTestCases() {
+		return Stream.of(Arguments.of(" ", UNICODE_NON_BREAK_SPACE),
+				Arguments.of("&nbsp;&nbsp;", UNICODE_NON_BREAK_SPACE), Arguments.of("&nbsp;", ""),
+				// Combination of doubled non-breaking spaces and empty spaces
+				Arguments.of("&nbsp;&nbsp; abc&nbsp;",
+						String.format("%s%sabc", UNICODE_NON_BREAK_SPACE, UNICODE_NON_BREAK_SPACE)),
+				Arguments.of("<br/>", ""), Arguments.of("&", "&amp;"), Arguments.of("<", "&lt;"),
+				Arguments.of("Hello & <br/>",
+						String.format("Hello%s&amp;%s", UNICODE_NON_BREAK_SPACE, UNICODE_NON_BREAK_SPACE)),
+				Arguments.of("", ""), Arguments.of(null, ""));
+	}
+
+}


### PR DESCRIPTION
## Summary
This PR refactors the `WordXmlEscape` and `HtmlEscape` classes to improve code readability, maintainability, and efficiency. Additionally, redundant escape logic has been removed since the `DocUtil.getEscapeAndCleanComment` method already handles the required escaping. Unit tests have been added and updated to ensure proper functionality and coverage.


## Changes

### Refactored WordXmlEscape:

- Simplified the call method by removing redundant escape logic.
- Retained only the necessary replacements before invoking DocUtil.getEscapeAndCleanComment.

### Refactored HtmlEscape:

- Removed redundant escape logic since DocUtil.getEscapeAndCleanComment already performs the required escaping.
- Improved the readability of the call method.

### Unit Tests:

- Added new unit tests for edge cases in `WordXmlEscape` and `HtmlEscape`.
- Updated existing tests to reflect the removal of redundant escape logic.

