### PR TITLE
fix: :bug: Add support for default validation message placeholders

### DIFF
--- a/src/main/java/com/ly/doc/constants/DocValidatorAnnotationEnum.java
+++ b/src/main/java/com/ly/doc/constants/DocValidatorAnnotationEnum.java
@@ -18,17 +18,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.ly.doc.constants;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * spring validator annotations
+ * Enumeration of Spring validator annotations with metadata for documentation generation.
+ * <p>
+ * This enum maps validation annotations to their default attribute values, enabling
+ * automatic replacement of placeholders in validation messages (e.g., {min}, {max}).
  *
  * @author yu 2019/9/19.
  */
-public enum DocValidatorAnnotationEnum {
+public enum DocValidatorAnnotationEnum implements ValidationAnnotationDefaultsProvider {
 
 	/**
 	 * Spring validator annotations `@NotEmpty`
@@ -83,7 +90,15 @@ public enum DocValidatorAnnotationEnum {
 	/**
 	 * Spring validator annotations `@Size`
 	 */
-	SIZE(JSRAnnotationConstants.SIZE),
+	SIZE(JSRAnnotationConstants.SIZE) {
+		public Map<String, String> getDefaultProperties() {
+			// @Size default values (min=0, max=Integer.MAX_VALUE)
+			Map<String, String> sizeDefaults = new HashMap<>(2);
+			sizeDefaults.put("min", "0");
+			sizeDefaults.put("max", Integer.toString(Integer.MAX_VALUE));
+			return sizeDefaults;
+		}
+	},
 
 	/**
 	 * Spring validator annotations `@Digits`
@@ -143,17 +158,34 @@ public enum DocValidatorAnnotationEnum {
 	/**
 	 * Spring validator annotations `@Length`
 	 */
-	LENGTH(JSRAnnotationConstants.LENGTH),
+	LENGTH(JSRAnnotationConstants.LENGTH) {
+		public Map<String, String> getDefaultProperties() {
+			// @Length default values (min=0, max=Integer.MAX_VALUE)
+			Map<String, String> lengthDefaults = new HashMap<>(2);
+			lengthDefaults.put("min", "0");
+			lengthDefaults.put("max", Integer.toString(Integer.MAX_VALUE));
+			return lengthDefaults;
+		}
+	},
 
 	/**
 	 * Spring validator annotations `@Range`
 	 */
-	RANGE(JSRAnnotationConstants.RANGE),
+	RANGE(JSRAnnotationConstants.RANGE) {
+		@Override
+		public Map<String, String> getDefaultProperties() {
+			// @Range default values (min=0, max=Long.MAX_VALUE)
+			Map<String, String> rangeDefaults = new HashMap<>(2);
+			rangeDefaults.put("min", "0");
+			rangeDefaults.put("max", Long.toString(Long.MAX_VALUE));
+			return rangeDefaults;
+		}
+	},
 
 	/**
 	 * Spring validator annotations `@Validated`
 	 */
-	VALIDATED(JSRAnnotationConstants.VALIDATED);
+	VALIDATED(JSRAnnotationConstants.VALIDATED),;
 
 	/**
 	 * annotation value
@@ -184,6 +216,32 @@ public enum DocValidatorAnnotationEnum {
 		EXCLUDED_ANNOTATIONS.add(NOT_NULL.value);
 		EXCLUDED_ANNOTATIONS.add(NULL.value);
 		EXCLUDED_ANNOTATIONS.add(VALIDATED.value);
+	}
+
+	/**
+	 * Looks up and returns the default attribute values for a validation annotation.
+	 * <p>
+	 * This method iterates through all {@link DocValidatorAnnotationEnum} entries to find
+	 * the matching annotation definition. If found, returns the associated default values
+	 * from {@link ValidationAnnotationDefaultsProvider#getDefaultProperties()}.
+	 * @param annotationName Fully qualified class name of the annotation (e.g.,
+	 * "javax.validation.constraints.Min")
+	 * @return An unmodifiable map of default attribute name-value pairs. Returns an empty
+	 * map if:
+	 * <ul>
+	 * <li>No matching annotation is found</li>
+	 * <li>The annotation does not define default values</li>
+	 * </ul>
+	 * @see DocValidatorAnnotationEnum
+	 * @see ValidationAnnotationDefaultsProvider
+	 */
+	public static Map<String, String> getDefaults(String annotationName) {
+		for (DocValidatorAnnotationEnum entry : values()) {
+			if (entry.value.equals(annotationName)) {
+				return entry.getDefaultProperties();
+			}
+		}
+		return Collections.emptyMap();
 	}
 
 }

--- a/src/main/java/com/ly/doc/constants/ValidationAnnotationDefaultsProvider.java
+++ b/src/main/java/com/ly/doc/constants/ValidationAnnotationDefaultsProvider.java
@@ -1,0 +1,59 @@
+/*
+ * smart-doc
+ *
+ * Copyright (C) 2018-2025 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ly.doc.constants;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Provides default attribute values for validation annotations.
+ * <p>
+ * Implementations of this interface should return immutable maps containing the default
+ * values for validation annotation attributes. These defaults are used for placeholder
+ * resolution in validation messages (e.g., replacing {min} with the actual default value
+ * from the annotation).
+ */
+public interface ValidationAnnotationDefaultsProvider {
+
+	/**
+	 * Gets the default attribute values for the associated validation annotation.
+	 * <p>
+	 * The returned map should be immutable and contain only primitive/wrapper values
+	 * converted to their String representations. Implementations should return an empty
+	 * map if no defaults are available.
+	 * @return Unmodifiable map of default attribute values, or empty map if none exist
+	 */
+	default Map<String, String> getDefaultProperties() {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Checks if the annotation has any default property values defined.
+	 * @return true if default properties are available, false otherwise
+	 */
+	default boolean hasDefaults() {
+		return !this.getDefaultProperties().isEmpty();
+	}
+
+}


### PR DESCRIPTION
- CLOSE ISSUE #1043 
- Implement ValidationAnnotationDefaultsProvider interface for default attribute values
- Update DocValidatorAnnotationEnum to provide default values for Size, Length, and Range annotations
- Modify JavaFieldUtil to use default values when processing validation annotations
- Add getDefaults() method to DocValidatorAnnotationEnum for retrieving default attribute values