### PR TITLE
feat(openapi): :sparkles: add support for generating tags by description or package name

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -1,7 +1,7 @@
 /*
  * smart-doc
  *
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,9 +25,21 @@ package com.ly.doc.builder.openapi;
 
 import com.ly.doc.builder.DocBuilderTemplate;
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.ComponentTypeEnum;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.MediaType;
+import com.ly.doc.constants.Methods;
+import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.factory.BuildTemplateFactory;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiExceptionStatus;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.DocMapping;
+import com.ly.doc.model.TagDoc;
 import com.ly.doc.model.openapi.OpenApiTag;
 import com.ly.doc.template.IDocBuildTemplate;
 import com.ly.doc.utils.DocUtil;
@@ -36,7 +48,13 @@ import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.ly.doc.constants.DocGlobalConstants.OPENAPI_2_COMPONENT_KRY;
@@ -171,12 +189,11 @@ public abstract class AbstractOpenApiBuilder {
 			}
 		}
 		for (Map.Entry<String, TagDoc> docEntry : DocMapping.TAG_DOC.entrySet()) {
-			String tag = docEntry.getKey();
 			tags.addAll(docEntry.getValue()
 				.getClazzDocs()
 				.stream()
 				// optimize tag content for compatible to swagger
-				.map(doc -> OpenApiTag.of(doc.getName(), doc.getDesc()))
+				.map(doc -> OpenApiTag.of(apiConfig.getOpenApiTagNameType(), doc))
 				.collect(Collectors.toSet()));
 		}
 		return pathMap;

--- a/src/main/java/com/ly/doc/constants/OpenApiTagNameTypeEnum.java
+++ b/src/main/java/com/ly/doc/constants/OpenApiTagNameTypeEnum.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2018-2025 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ly.doc.constants;
+
+/**
+ * Enum representing the possible sources for generating tag names in OpenAPI
+ * specifications. Each enum value defines a strategy for determining the value of
+ * `tags[].name` in the OpenAPI document.
+ *
+ * <p>
+ * Supported strategies include:
+ * <ul>
+ * <li>Using the class name of the controller</li>
+ * <li>Using the controller's description</li>
+ * <li>Using the controller's package name</li>
+ * </ul>
+ *
+ * @author Lin
+ * @version 3.1.1
+ */
+public enum OpenApiTagNameTypeEnum {
+
+	/**
+	 * Use the simple class name of the controller as the tag name.
+	 * <p>
+	 * This is the default strategy. The tag name will be derived from the controller
+	 * class name without its package prefix.
+	 * </p>
+	 * <p>
+	 * Example: For a controller class named `UserController`, the tag name will be
+	 * `UserController`.
+	 * </p>
+	 */
+	CLASS_NAME,
+
+	/**
+	 * Use the controller's description as the tag name.
+	 * <p>
+	 * The description is typically defined in the controller's documentation (e.g., via
+	 * Javadoc or configuration). This allows for more descriptive and user-friendly tag
+	 * names.
+	 * </p>
+	 * <p>
+	 * Example: If the controller has a description `User Management API`, the tag name
+	 * will be `User Management API`.
+	 * </p>
+	 */
+	DESCRIPTION,
+
+	/**
+	 * Use the full package name of the controller as the tag name.
+	 * <p>
+	 * This strategy is useful when you want to organize tags by package structure,
+	 * especially in large projects.
+	 * </p>
+	 * <p>
+	 * Example: For a controller in package `com.example.controller.user`, the tag name
+	 * will be `com.example.controller.user`.
+	 * </p>
+	 */
+	PACKAGE_NAME;
+
+}

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,10 +18,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.ly.doc.model;
 
 import com.ly.doc.constants.ComponentTypeEnum;
 import com.ly.doc.constants.DocLanguage;
+import com.ly.doc.constants.OpenApiTagNameTypeEnum;
 import com.ly.doc.handler.ICustomJavaMethodHandler;
 import com.ly.doc.model.jmeter.JMeter;
 import com.ly.doc.model.rpc.RpcApiDependency;
@@ -411,6 +413,33 @@ public class ApiConfig {
 	 * @see ComponentTypeEnum
 	 */
 	private ComponentTypeEnum componentType = ComponentTypeEnum.RANDOM;
+
+	/**
+	 * Strategy for determining the source of OpenAPI tag names.
+	 * <p>
+	 * This field specifies how the tag names in the generated OpenAPI document are
+	 * derived. Supported strategies include:
+	 * </p>
+	 *
+	 * <ul>
+	 * <li>{@link OpenApiTagNameTypeEnum#CLASS_NAME}: Use the controller's simple class
+	 * name (e.g., "UserController")</li>
+	 * <li>{@link OpenApiTagNameTypeEnum#DESCRIPTION}: Use the controller's description
+	 * (e.g., from {@link ApiDoc#getDesc()})</li>
+	 * <li>{@link OpenApiTagNameTypeEnum#PACKAGE_NAME}: Use the controller's full package
+	 * name (e.g., "com.example.controller")</li>
+	 * </ul>
+	 *
+	 * <p>
+	 * This setting affects how API operations are grouped in the OpenAPI documentation.
+	 * Choose the strategy that best aligns with your API organization needs.
+	 * </p>
+	 *
+	 * @see OpenApiTagNameTypeEnum
+	 * @see ApiDoc#getDesc() for description source details
+	 * @since 3.1.1
+	 */
+	private OpenApiTagNameTypeEnum openApiTagNameType = OpenApiTagNameTypeEnum.CLASS_NAME;
 
 	/**
 	 * whether to build the doc incrementally
@@ -1154,6 +1183,15 @@ public class ApiConfig {
 
 	public void setEnumConvertor(boolean enumConvertor) {
 		this.enumConvertor = enumConvertor;
+	}
+
+	public OpenApiTagNameTypeEnum getOpenApiTagNameType() {
+		return openApiTagNameType;
+	}
+
+	public ApiConfig setOpenApiTagNameType(OpenApiTagNameTypeEnum openApiTagNameType) {
+		this.openApiTagNameType = openApiTagNameType;
+		return this;
 	}
 
 }

--- a/src/main/java/com/ly/doc/model/DocMapping.java
+++ b/src/main/java/com/ly/doc/model/DocMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,18 +18,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.ly.doc.model;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
+ * Doc tag mapping
+ *
  * @author CKM Relational Mapping 2023/03/20 10:13:00
  */
 public class DocMapping {
 
+	/**
+	 * key:tag value:ApiDoc
+	 */
 	public static Map<String, TagDoc> TAG_DOC = new ConcurrentHashMap<>(64);
 
 	public static void tagDocPut(String tag, ApiDoc apiDoc, ApiMethodDoc methodDoc) {

--- a/src/main/java/com/ly/doc/model/openapi/OpenApiTag.java
+++ b/src/main/java/com/ly/doc/model/openapi/OpenApiTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,6 +20,9 @@
  */
 
 package com.ly.doc.model.openapi;
+
+import com.ly.doc.constants.OpenApiTagNameTypeEnum;
+import com.ly.doc.model.ApiDoc;
 
 import java.util.Objects;
 
@@ -49,8 +52,31 @@ public class OpenApiTag {
 		this.description = description;
 	}
 
+	/**
+	 * create open api tag
+	 * @param name tag name
+	 * @param description tag description
+	 * @return OpenApiTag
+	 */
 	public static OpenApiTag of(String name, String description) {
 		return new OpenApiTag(name, description);
+	}
+
+	/**
+	 * create open api tag
+	 * @param openApiTagNameType open api tag name type
+	 * @param apiDoc api doc
+	 * @return OpenApiTag
+	 */
+	public static OpenApiTag of(OpenApiTagNameTypeEnum openApiTagNameType, ApiDoc apiDoc) {
+		switch (openApiTagNameType) {
+			case DESCRIPTION:
+				return new OpenApiTag(apiDoc.getDesc(), apiDoc.getDesc());
+			case PACKAGE_NAME:
+				return new OpenApiTag(apiDoc.getPackageName(), apiDoc.getDesc());
+			default:
+				return of(apiDoc.getName(), apiDoc.getDesc());
+		}
 	}
 
 	public String getName() {


### PR DESCRIPTION
feat(openapi): :sparkles: add support for generating tags by description or package name

- Add OpenApiTagNameTypeEnum to define tag name generation strategies
- Implement tag name generation logic in AbstractOpenApiBuilder
- Update ApiConfig to include openApiTagNameType setting
- Modify OpenApiTag class to support new tag name generation methods


## Documents  PR
[smart-doc-group.github.io#196](https://github.com/smart-doc-group/smart-doc-group.github.io/pull/196)