### PR TITLE
fix(openapi): generate the example value based on the field type instead of always String

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -26,7 +26,14 @@ import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.Methods;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
-import com.ly.doc.model.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiExceptionStatus;
+import com.ly.doc.model.ApiMethodDoc;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.TagDoc;
 import com.ly.doc.model.openapi.OpenApiTag;
 import com.ly.doc.utils.JsonUtil;
 import com.ly.doc.utils.OpenApiSchemaUtil;
@@ -35,7 +42,14 @@ import com.power.common.util.FileUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  *
@@ -236,7 +250,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 				parameters.put("name", header.getName());
 				parameters.put("required", header.isRequired());
 				parameters.put("description", header.getDesc());
-				parameters.put("example", header.getValue());
+				parameters.put("example", getExampleValueBasedOnTypeForApiReqParam(header));
 				parameters.put("schema", buildParametersSchema(header));
 				parameters.put("in", "header");
 				parametersList.add(parameters);
@@ -251,7 +265,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 		parameters = new HashMap<>(20);
 		// add mock value for parameters
 		if (StringUtils.isNotEmpty(apiParam.getValue())) {
-			parameters.put("example", apiParam.getValue());
+			parameters.put("example", getExampleValueBasedOnTypeForApiParam(apiParam));
 		}
 		if (!hasItems) {
 			parameters.put("name", apiParam.getField());

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -248,7 +248,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 					parameters.put("type", DocUtil.javaTypeToOpenApiTypeConvert(header.getType()));
 					parameters.put("description", header.getDesc());
 					parameters.put("required", header.isRequired());
-					parameters.put("example", header.getValue());
+					parameters.put("example", getExampleValueBasedOnTypeForApiReqParam(header));
 					parameters.put("schema", buildParametersSchema(header));
 					parameters.put("in", "header");
 					parametersList.add(parameters);


### PR DESCRIPTION
This PR is used to fix the issue https://github.com/TongchengOpenSource/smart-doc/issues/1059 

For the fields in the Entity model like this:

```
/**
     * 是否支持单点登录
     * @mock true
     */
    private boolean ssoLogin;

    /**
     * 应用的索引，值越小，排列越靠前
     * @mock 1111
     */
    private int appIndex;
```

- The OpenAPI result before fix

```
 "ssoLogin": {
    "format": "boolean",
    "description": "是否支持单点登录",
    "type": "boolean",
    "example": "true"
  },
  "appIndex": {
    "format": "int32",
    "description": "应用的索引，值越小，排列越靠前",
    "type": "integer",
    "example": "0"
  }
```

- The OpenAPI result after  fix

```
   "ssoLogin": {
    "format": "boolean",
    "description": "是否支持单点登录",
    "type": "boolean",
    "example": true
  },
  "appIndex": {
    "format": "int32",
    "description": "应用的索引，值越小，排列越靠前",
    "type": "integer",
    "example": 0
  }
```