### PR TITLE
feat: Add allowSelfReference configuration to control self-reference …

### DIFF
--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -496,6 +496,13 @@ public class ApiConfig {
 	 */
 	private boolean enumConvertor = Boolean.FALSE;
 
+	/**
+	 * allow self reference recursion
+	 *
+	 * @since 3.1.0
+	 */
+	private boolean allowSelfReference = Boolean.FALSE;
+
 	public static ApiConfig getInstance() {
 		return instance;
 	}
@@ -1183,6 +1190,14 @@ public class ApiConfig {
 
 	public void setEnumConvertor(boolean enumConvertor) {
 		this.enumConvertor = enumConvertor;
+	}
+
+	public boolean isAllowSelfReference() {
+		return allowSelfReference;
+	}
+
+	public void setAllowSelfReference(boolean allowSelfReference) {
+		this.allowSelfReference = allowSelfReference;
 	}
 
 	public OpenApiTagNameTypeEnum getOpenApiTagNameType() {


### PR DESCRIPTION
Introduces configurable self-reference handling in API documentation:
- New 'allowSelfReference' boolean option in ApiConfig (default: false)
- Enables recursive expansion of self-referencing structures up to 2 levels
- Supports tree-like data structures (menus, categories, etc.)
- Maintains backward compatibility with existing behavior
- Prevents infinite recursion while showing meaningful nested structures

When enabled, self-referencing fields like 'List<SysMenuInfoVO> children' 
will display full structure instead of empty or reference-only content.

![image](https://github.com/user-attachments/assets/930ad4f9-b09a-4f2f-81c3-fdbd2a2e11b0)
