### PR TITLE
feat(template):  :sparkles:  add method to determine if a method should be skipped in documentation

### DIFF
--- a/src/main/java/com/ly/doc/template/IJavadocDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IJavadocDocTemplate.java
@@ -356,6 +356,13 @@ public interface IJavadocDocTemplate<T extends JavadocJavaMethod> extends IBaseD
 			if (Objects.nonNull(method.getTagByName(IGNORE))) {
 				continue;
 			}
+
+			// skip method
+			boolean skipMethod = this.skipMethod(cls, method, apiConfig, projectBuilder);
+			if (skipMethod) {
+				continue;
+			}
+
 			if (StringUtil.isEmpty(method.getComment()) && apiConfig.isStrict()) {
 				throw new RuntimeException(
 						"Unable to find comment for method " + method.getName() + " in " + cls.getCanonicalName());
@@ -394,7 +401,7 @@ public interface IJavadocDocTemplate<T extends JavadocJavaMethod> extends IBaseD
 				Function.identity(), this::mergeJavadocMethods, LinkedHashMap::new));
 
 		int methodOrder = 0;
-		List<T> javadocJavaMethods = new ArrayList<>(methodMap.values().size());
+		List<T> javadocJavaMethods = new ArrayList<>(methodMap.size());
 		for (T method : methodMap.values()) {
 			methodOrder++;
 			method.setOrder(methodOrder);
@@ -441,6 +448,31 @@ public interface IJavadocDocTemplate<T extends JavadocJavaMethod> extends IBaseD
 			existing.setVersion(replacement.getVersion());
 		}
 		return existing;
+	}
+
+	/**
+	 * Determines whether the specified method should be skipped during documentation
+	 * generation.
+	 * <p>
+	 * If this method returns {@code true}, the method will be excluded from the generated
+	 * documentation. If it returns {@code false}, the method will be included.
+	 * </p>
+	 * <p>
+	 * The default implementation always returns {@code false}, meaning no methods are
+	 * skipped by default. Subclasses may override this method to provide custom logic for
+	 * excluding certain methods.
+	 * </p>
+	 * @param cls The Java class containing the method.
+	 * @param method The Java method to check.
+	 * @param apiConfig The API configuration object, used to control documentation
+	 * behavior.
+	 * @param projectBuilder The project documentation configuration builder.
+	 * @return {@code true} if the method should be skipped (not documented),
+	 * {@code false} if it should be included.
+	 */
+	default boolean skipMethod(final JavaClass cls, final JavaMethod method, ApiConfig apiConfig,
+			ProjectDocConfigBuilder projectBuilder) {
+		return false;
 	}
 
 }


### PR DESCRIPTION
- Add `skipMethod` method to `IJavadocDocTemplate` interface
- Implement method to check if a method should be included in the documentation
- Update processMethodsList to use the new `skipMethod` method