### PR TITLE
fix(openapi): :bug:  ensure tag names in paths match configured strategy

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -24,6 +24,7 @@ package com.ly.doc.builder.openapi;
 
 import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.Methods;
+import com.ly.doc.constants.OpenApiTagNameTypeEnum;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.helper.JavaProjectBuilderHelper;
 import com.ly.doc.model.ApiConfig;
@@ -159,7 +160,17 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 		// } else {
 		// request.put("tags", new String[]{tag});
 		// }
-		request.put("tags", apiMethodDoc.getTagRefs().stream().map(TagDoc::getTag).toArray());
+		OpenApiTagNameTypeEnum openApiTagNameType = apiConfig.getOpenApiTagNameType();
+		switch (openApiTagNameType) {
+			case DESCRIPTION:
+				request.put("tags", new String[] { apiDoc.getDesc() });
+				break;
+			case PACKAGE_NAME:
+				request.put("tags", new String[] { apiDoc.getPackageName() });
+				break;
+			default:
+				request.put("tags", apiMethodDoc.getTagRefs().stream().map(TagDoc::getTag).toArray());
+		}
 		request.put("requestBody", this.buildRequestBody(apiConfig, apiMethodDoc));
 		request.put("parameters", this.buildParameters(apiMethodDoc));
 		request.put("responses", this.buildResponses(apiConfig, apiMethodDoc, apiExceptionStatuses));

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -1201,6 +1201,9 @@ public class ApiConfig {
 	}
 
 	public OpenApiTagNameTypeEnum getOpenApiTagNameType() {
+		if (Objects.isNull(openApiTagNameType)) {
+			return OpenApiTagNameTypeEnum.CLASS_NAME;
+		}
 		return openApiTagNameType;
 	}
 

--- a/src/main/java/com/ly/doc/model/openapi/OpenApiTag.java
+++ b/src/main/java/com/ly/doc/model/openapi/OpenApiTag.java
@@ -69,6 +69,9 @@ public class OpenApiTag {
 	 * @return OpenApiTag
 	 */
 	public static OpenApiTag of(OpenApiTagNameTypeEnum openApiTagNameType, ApiDoc apiDoc) {
+		if (Objects.isNull(openApiTagNameType)) {
+			return of(apiDoc.getName(), apiDoc.getDesc());
+		}
 		switch (openApiTagNameType) {
 			case DESCRIPTION:
 				return new OpenApiTag(apiDoc.getDesc(), apiDoc.getDesc());


### PR DESCRIPTION
- bug from #1060
- Add default value for openApiTagNameType in ApiConfig
- Implement fallback logic in OpenApiBuilder and OpenApiTag
- Use class name as default tag name when openApiTagNameType is null
- The update ensures that the tag names used in both the top-level tags array and the paths section are consistent based on the selected configuration, thereby resolving the linkage issues and making the configuration work as intended.
- closed #964