### PR TITLE
feat: Fixed the pathPrefix generation error in the OpenAPI document.

### DIFF
--- a/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/AbstractOpenApiBuilder.java
@@ -169,7 +169,8 @@ public abstract class AbstractOpenApiBuilder {
 	 * @return Map of paths
 	 */
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> buildPaths(ApiConfig apiConfig, ApiSchema<ApiDoc> apiSchema, Set<OpenApiTag> tags) {
+	public Map<String, Object> buildPaths(ApiConfig apiConfig, ApiSchema<ApiDoc> apiSchema, Set<OpenApiTag> tags,
+			boolean isSwagger) {
 		Map<String, Object> pathMap = new LinkedHashMap<>(500);
 
 		List<ApiDoc> apiDocs = apiSchema.getApiDatas();
@@ -181,7 +182,7 @@ public abstract class AbstractOpenApiBuilder {
 				String[] paths = methodDoc.getPath().split(";");
 				for (String path : paths) {
 					path = path.trim();
-					if (StringUtil.isNotEmpty(apiConfig.getPathPrefix())) {
+					if (StringUtil.isNotEmpty(apiConfig.getPathPrefix()) && isSwagger) {
 						path = path.replace(apiConfig.getPathPrefix(), "");
 					}
 					Map<String, Object> request = this.buildPathUrls(apiConfig, methodDoc, methodDoc.getClazzDoc(),

--- a/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/OpenApiBuilder.java
@@ -110,7 +110,7 @@ public class OpenApiBuilder extends AbstractOpenApiBuilder {
 		json.put("servers", buildServers(config));
 		Set<OpenApiTag> tags = new HashSet<>();
 		json.put("tags", tags);
-		json.put("paths", this.buildPaths(config, apiSchema, tags));
+		json.put("paths", this.buildPaths(config, apiSchema, tags, false));
 		json.put("components", this.buildComponentsSchema(apiSchema));
 
 		String filePath = config.getOutPath();

--- a/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
+++ b/src/main/java/com/ly/doc/builder/openapi/SwaggerBuilder.java
@@ -109,7 +109,7 @@ public class SwaggerBuilder extends AbstractOpenApiBuilder {
 				: DocGlobalConstants.PATH_DELIMITER);
 		Set<OpenApiTag> tags = new HashSet<>();
 		json.put("tags", tags);
-		json.put("paths", buildPaths(config, apiSchema, tags));
+		json.put("paths", buildPaths(config, apiSchema, tags, true));
 		json.put("definitions", buildComponentsSchema(apiSchema));
 
 		String filePath = config.getOutPath();


### PR DESCRIPTION
  The original prefix created by `pathPrefix` has been overridden with a new predefined value.

