### PR TITLE
fix(extension): :bug: resolve JsonNaming annotation value

### DIFF
--- a/src/main/java/com/ly/doc/extension/json/PropertyNameHelper.java
+++ b/src/main/java/com/ly/doc/extension/json/PropertyNameHelper.java
@@ -20,9 +20,12 @@
  */
 package com.ly.doc.extension.json;
 
+import com.ly.doc.builder.ProjectDocConfigBuilder;
 import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.utils.DocUtil;
 import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.model.JavaAnnotation;
+import com.thoughtworks.qdox.model.expression.AnnotationValue;
 
 import java.util.List;
 
@@ -79,16 +82,23 @@ public class PropertyNameHelper {
 
 	/**
 	 * Translates Java annotations to property naming strategies.
+	 * @param projectBuilder the project builder
 	 * @param javaAnnotations List of Java annotations on a property
 	 * @return The property naming strategy, or null if no matching strategy is found
 	 */
-	public static PropertyNamingStrategies.NamingBase translate(List<JavaAnnotation> javaAnnotations) {
+	public static PropertyNamingStrategies.NamingBase translate(ProjectDocConfigBuilder projectBuilder,
+			List<JavaAnnotation> javaAnnotations) {
 		for (JavaAnnotation annotation : javaAnnotations) {
 			String simpleAnnotationName = annotation.getType().getValue();
-			// jackson
+			// jackson JsonNaming
 			if (DocAnnotationConstants.JSON_NAMING.equalsIgnoreCase(simpleAnnotationName)) {
-				String value = annotation.getProperty("value").getParameterValue().toString().toLowerCase();
-				return jackSonTranslate(value);
+				// annotationValue (Fix issues #1103)
+				AnnotationValue annotationValue = annotation.getProperty(DocAnnotationConstants.VALUE_PROP);
+				// get value
+				String value = DocUtil.resolveAnnotationValue(projectBuilder.getApiConfig().getClassLoader(),
+						annotationValue);
+
+				return jackSonTranslate(value.toLowerCase());
 			}
 
 		}

--- a/src/main/java/com/ly/doc/handler/JaxrsPathHandler.java
+++ b/src/main/java/com/ly/doc/handler/JaxrsPathHandler.java
@@ -21,6 +21,7 @@
 package com.ly.doc.handler;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
+import com.ly.doc.constants.DocAnnotationConstants;
 import com.ly.doc.constants.DocGlobalConstants;
 import com.ly.doc.constants.JAXRSAnnotations;
 import com.ly.doc.constants.JakartaJaxrsAnnotations;
@@ -93,7 +94,7 @@ public class JaxrsPathHandler {
 			// method level annotation will override class level annotation
 			if (annotationName.equals(JakartaJaxrsAnnotations.JAX_CONSUMES_FULLY)
 					|| annotationName.equals(JAXRSAnnotations.JAX_CONSUMES_FULLY)) {
-				Object value = annotation.getNamedParameter("value");
+				Object value = annotation.getNamedParameter(DocAnnotationConstants.VALUE_PROP);
 				if (Objects.nonNull(value)) {
 					mediaType = MediaType.valueOf(value.toString());
 				}

--- a/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
+++ b/src/main/java/com/ly/doc/helper/ParamsBuildHelper.java
@@ -217,7 +217,7 @@ public class ParamsBuildHelper extends BaseHelper {
 		// ignore
 		if (Objects.nonNull(cls)) {
 			List<JavaAnnotation> clsAnnotation = cls.getAnnotations();
-			fieldNameConvert = PropertyNameHelper.translate(clsAnnotation);
+			fieldNameConvert = PropertyNameHelper.translate(projectBuilder, clsAnnotation);
 		}
 
 		String[] globGicName = DocClassUtil.getSimpleGicName(className);

--- a/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
@@ -21,11 +21,33 @@
 package com.ly.doc.template;
 
 import com.ly.doc.builder.ProjectDocConfigBuilder;
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.DocGlobalConstants;
+import com.ly.doc.constants.DocTags;
+import com.ly.doc.constants.FrameworkEnum;
+import com.ly.doc.constants.Methods;
+import com.ly.doc.constants.SpringMvcAnnotations;
+import com.ly.doc.constants.SpringMvcRequestAnnotationsEnum;
 import com.ly.doc.handler.SpringMVCRequestHeaderHandler;
 import com.ly.doc.handler.SpringMVCRequestMappingHandler;
-import com.ly.doc.model.*;
-import com.ly.doc.model.annotation.*;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDoc;
+import com.ly.doc.model.ApiExceptionStatus;
+import com.ly.doc.model.ApiParam;
+import com.ly.doc.model.ApiReqParam;
+import com.ly.doc.model.ApiSchema;
+import com.ly.doc.model.ExceptionAdviceMethod;
+import com.ly.doc.model.WebSocketDoc;
+import com.ly.doc.model.annotation.EntryAnnotation;
+import com.ly.doc.model.annotation.ExceptionAdviceAnnotation;
+import com.ly.doc.model.annotation.FrameworkAnnotations;
+import com.ly.doc.model.annotation.HeaderAnnotation;
+import com.ly.doc.model.annotation.MappingAnnotation;
+import com.ly.doc.model.annotation.PathVariableAnnotation;
+import com.ly.doc.model.annotation.RequestBodyAnnotation;
+import com.ly.doc.model.annotation.RequestParamAnnotation;
+import com.ly.doc.model.annotation.RequestPartAnnotation;
+import com.ly.doc.model.annotation.ServerEndpointAnnotation;
 import com.ly.doc.model.request.RequestMapping;
 import com.ly.doc.utils.JavaClassValidateUtil;
 import com.power.common.util.DateTimeUtil;
@@ -35,7 +57,13 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaMethod;
 
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -270,7 +298,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 				isExceptionHandlerMethod = true;
 			}
 			if (SpringMvcAnnotations.RESPONSE_STATUS.equals(annotationName)) {
-				Object consumes = annotation.getNamedParameter("value");
+				Object consumes = annotation.getNamedParameter(DocAnnotationConstants.VALUE_PROP);
 				if (Objects.nonNull(consumes)) {
 					status = consumes.toString();
 				}


### PR DESCRIPTION
- Update PropertyNameHelper.translate method to properly resolve the value of JsonNaming annotation
- Add ProjectDocConfigBuilder parameter to the translate method
- Use DocUtil.resolveAnnotationValue to get the correct value from the annotation
- Fix issue #1103 related to JsonNaming annotation resolution