### PR TITLE
fix(enum): Fix the index out-of-bounds exception when the enumeration value is empty.

### DIFF
--- a/src/main/java/com/ly/doc/utils/JavaClassUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassUtil.java
@@ -1693,7 +1693,9 @@ public class JavaClassUtil {
 
 		if (enumValue == null) {
 			enumValues = items.stream().map(Item::getName).collect(Collectors.toList());
-			enumValue = enumValues.get(0);
+			if (CollectionUtil.isNotEmpty(enumValues)) {
+				enumValue = enumValues.get(0);
+			}
 			type = ParamTypeConstants.PARAM_TYPE_ENUM;
 		}
 


### PR DESCRIPTION
When an enumeration value has no value, parsing the enumeration value list will result in an error, as shown below:
```java
@Getter
@AllArgsConstructor
public enum TestEnum {

    ;

    @JsonValue
    private final Integer id;
    private final String text;

}
```
Error message as follows:
<img width="1311" height="462" alt="image" src="https://github.com/user-attachments/assets/eb6a7908-1afc-4c00-9c85-e649af8716c9" />
