### PR TITLE
fix: :bug:  support path attribute in `@FeignClient` and refactor annotation constants

### DIFF
--- a/src/main/java/com/ly/doc/constants/DocAnnotationConstants.java
+++ b/src/main/java/com/ly/doc/constants/DocAnnotationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -214,5 +214,57 @@ public interface DocAnnotationConstants {
 	 * {@code jakarta.websocket.server.PathParam}
 	 */
 	String PATH_PARAM = "PathParam";
+
+	/**
+	 * The name of the 'consumes' attribute in Spring MVC request mapping annotations,
+	 * used to specify the media types that the annotated handler method can consume.
+	 * <p>
+	 * Corresponds to
+	 * {@code org.springframework.web.bind.annotation.RequestMapping#consumes()}
+	 * </p>
+	 */
+	String CONSUMES = "consumes";
+
+	/**
+	 * The name of the 'produces' attribute in Spring MVC request mapping annotations,
+	 * used to specify the media types that the annotated handler method can produce.
+	 * <p>
+	 * Corresponds to
+	 * {@code org.springframework.web.bind.annotation.RequestMapping#produces()}
+	 * </p>
+	 */
+	String PRODUCES = "produces";
+
+	/**
+	 * The name of the 'method' attribute in Spring MVC request mapping annotations, used
+	 * to specify the HTTP request methods that the annotated handler method supports.
+	 * <p>
+	 * Corresponds to
+	 * {@code org.springframework.web.bind.annotation.RequestMapping#method()}
+	 * </p>
+	 */
+	String METHOD = "method";
+
+	/**
+	 * The name of the 'params' attribute in Spring MVC request mapping annotations, used
+	 * to specify HTTP request parameters that must be present for the mapping to be
+	 * matched.
+	 * <p>
+	 * Corresponds to
+	 * {@code org.springframework.web.bind.annotation.RequestMapping#params()}
+	 * </p>
+	 */
+	String PARAMS = "params";
+
+	/**
+	 * Common property names used to define request mapping paths. Typically used in
+	 * annotations like {@code @RequestMapping}, {@code @GetMapping}, etc. Corresponds to
+	 * 'value' and 'path' attributes which are synonyms in Spring MVC.
+	 *
+	 * <p>
+	 * Used to configure URL mapping paths for handler methods.
+	 * </p>
+	 */
+	String[] PATH_MAPPING_PROPS = { VALUE_PROP, PATH_PROP };
 
 }

--- a/src/main/java/com/ly/doc/constants/SpringMvcAnnotations.java
+++ b/src/main/java/com/ly/doc/constants/SpringMvcAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -40,7 +40,13 @@ public interface SpringMvcAnnotations {
 
 	String DELETE_MAPPING = "DeleteMapping";
 
+	@Deprecated
 	String REQUEST_HERDER = "RequestHeader";
+
+	/**
+	 * RequestHeader
+	 */
+	String REQUEST_HEADER = "RequestHeader";
 
 	String REQUEST_PARAM = "RequestParam";
 

--- a/src/main/java/com/ly/doc/handler/SpringMVCRequestHeaderHandler.java
+++ b/src/main/java/com/ly/doc/handler/SpringMVCRequestHeaderHandler.java
@@ -49,7 +49,7 @@ public class SpringMVCRequestHeaderHandler implements IHeaderHandler {
 	@Override
 	public HeaderAnnotation getHeaderAnnotation() {
 		return HeaderAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.REQUEST_HERDER)
+			.setAnnotationName(SpringMvcAnnotations.REQUEST_HEADER)
 			.setValueProp(DocAnnotationConstants.VALUE_PROP)
 			.setDefaultValueProp(DocAnnotationConstants.DEFAULT_VALUE_PROP)
 			.setRequiredProp(DocAnnotationConstants.REQUIRED_PROP);

--- a/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -108,15 +108,17 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 	@Override
 	public FrameworkAnnotations registeredAnnotations() {
 		FrameworkAnnotations annotations = FrameworkAnnotations.builder();
+
+		// Header annotation
 		HeaderAnnotation headerAnnotation = HeaderAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.REQUEST_HERDER)
+			.setAnnotationName(SpringMvcAnnotations.REQUEST_HEADER)
 			.setValueProp(DocAnnotationConstants.VALUE_PROP)
 			.setDefaultValueProp(DocAnnotationConstants.DEFAULT_VALUE_PROP)
 			.setRequiredProp(DocAnnotationConstants.REQUIRED_PROP);
 		// add header annotation
 		annotations.setHeaderAnnotation(headerAnnotation);
 
-		// add entry annotation
+		// Entry annotations (Controller, RestController)
 		Map<String, EntryAnnotation> entryAnnotations = new HashMap<>(16);
 		EntryAnnotation controllerAnnotation = EntryAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.CONTROLLER)
@@ -128,108 +130,43 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 		entryAnnotations.put(restController.getAnnotationName(), restController);
 		annotations.setEntryAnnotations(entryAnnotations);
 
-		// add request body annotation
+		// RequestBody annotation
 		RequestBodyAnnotation bodyAnnotation = RequestBodyAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.REQUEST_BODY)
 			.setAnnotationFullyName(SpringMvcAnnotations.REQUEST_BODY_FULLY);
 		annotations.setRequestBodyAnnotation(bodyAnnotation);
 
-		// request param annotation
-		RequestParamAnnotation requestAnnotation = RequestParamAnnotation.builder()
+		// RequestParam annotation
+		RequestParamAnnotation requestParamAnnotation = RequestParamAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.REQUEST_PARAM)
 			.setDefaultValueProp(DocAnnotationConstants.DEFAULT_VALUE_PROP)
 			.setRequiredProp(DocAnnotationConstants.REQUIRED_PROP);
-		annotations.setRequestParamAnnotation(requestAnnotation);
+		annotations.setRequestParamAnnotation(requestParamAnnotation);
 
-		// request part annotation
+		// RequestPart annotation
 		RequestPartAnnotation requestPartAnnotation = RequestPartAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.REQUEST_PART)
 			.setDefaultValueProp(DocAnnotationConstants.DEFAULT_VALUE_PROP)
 			.setRequiredProp(DocAnnotationConstants.REQUIRED_PROP);
 		annotations.setRequestPartAnnotation(requestPartAnnotation);
 
-		// add path variable annotation
+		// PathVariable annotation
 		PathVariableAnnotation pathVariableAnnotation = PathVariableAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.PATH_VARIABLE)
 			.setDefaultValueProp(DocAnnotationConstants.DEFAULT_VALUE_PROP)
 			.setRequiredProp(DocAnnotationConstants.REQUIRED_PROP);
 		annotations.setPathVariableAnnotation(pathVariableAnnotation);
 
-		// add websocket server endpoint annotation
+		// ServerEndpoint annotation (WebSocket)
 		ServerEndpointAnnotation serverEndpointAnnotation = ServerEndpointAnnotation.builder()
 			.setAnnotationName(SpringMvcAnnotations.SERVER_ENDPOINT);
 		annotations.setServerEndpointAnnotation(serverEndpointAnnotation);
 
 		// add mapping annotations
-		Map<String, MappingAnnotation> mappingAnnotations = new HashMap<>(16);
-
-		MappingAnnotation requestMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.REQUEST_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setMethodProp("method")
-			.setParamsProp("params")
-			.setScope("class", "method")
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(requestMappingAnnotation.getAnnotationName(), requestMappingAnnotation);
-
-		MappingAnnotation postMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.POST_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setMethodProp("method")
-			.setParamsProp("params")
-			.setMethodType(Methods.POST.getValue())
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(postMappingAnnotation.getAnnotationName(), postMappingAnnotation);
-
-		MappingAnnotation getMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.GET_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setMethodProp("method")
-			.setParamsProp("params")
-			.setMethodType(Methods.GET.getValue())
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(getMappingAnnotation.getAnnotationName(), getMappingAnnotation);
-
-		MappingAnnotation putMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.PUT_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setParamsProp("params")
-			.setMethodProp("method")
-			.setMethodType(Methods.PUT.getValue())
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(putMappingAnnotation.getAnnotationName(), putMappingAnnotation);
-
-		MappingAnnotation patchMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.PATCH_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setMethodProp("method")
-			.setParamsProp("params")
-			.setMethodType(Methods.PATCH.getValue())
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(patchMappingAnnotation.getAnnotationName(), patchMappingAnnotation);
-
-		MappingAnnotation deleteMappingAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(SpringMvcAnnotations.DELETE_MAPPING)
-			.setConsumesProp("consumes")
-			.setProducesProp("produces")
-			.setMethodProp("method")
-			.setParamsProp("params")
-			.setMethodType(Methods.DELETE.getValue())
-			.setPathProps(DocAnnotationConstants.VALUE_PROP, DocAnnotationConstants.PATH_PROP);
-		mappingAnnotations.put(deleteMappingAnnotation.getAnnotationName(), deleteMappingAnnotation);
-
-		MappingAnnotation feignClientAnnotation = MappingAnnotation.builder()
-			.setAnnotationName(DocGlobalConstants.FEIGN_CLIENT)
-			.setAnnotationFullyName(DocGlobalConstants.FEIGN_CLIENT_FULLY);
-		mappingAnnotations.put(feignClientAnnotation.getAnnotationName(), feignClientAnnotation);
+		Map<String, MappingAnnotation> mappingAnnotations = buildSpringMappingAnnotations();
 		annotations.setMappingAnnotations(mappingAnnotations);
 
-		// Add Exception advice
+		// Exception advice annotations
 		Map<String, ExceptionAdviceAnnotation> exceptionAdviceAnnotations = new HashMap<>(16);
 
 		ExceptionAdviceAnnotation controllerAdviceAnnotation = ExceptionAdviceAnnotation.builder()
@@ -430,6 +367,91 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 					+ "  \"error\": \"Unsupported Media Type\",\n" + "  \"path\": \"/api/v1/xx\"\n" + "} ")
 			.setExceptionResponseParams(Arrays.asList(errorParam, pathParam, timestampParam, status415Param)));
 		return exceptionStatusList;
+	}
+
+	/**
+	 * Builds and returns all Spring MVC request mapping annotations
+	 * including @RequestMapping, @GetMapping, @PostMapping, etc., with consistent
+	 * attribute configurations.
+	 * @return a map of annotation name to {@link MappingAnnotation}
+	 */
+	private Map<String, MappingAnnotation> buildSpringMappingAnnotations() {
+		Map<String, MappingAnnotation> mappingAnnotations = new HashMap<>(16);
+
+		// Common properties
+		String consumes = DocAnnotationConstants.CONSUMES;
+		String produces = DocAnnotationConstants.PRODUCES;
+		String method = DocAnnotationConstants.METHOD;
+		String params = DocAnnotationConstants.PARAMS;
+		String[] pathProps = DocAnnotationConstants.PATH_MAPPING_PROPS;
+
+		// @RequestMapping
+		MappingAnnotation requestMapping = MappingAnnotation.builder()
+			.setAnnotationName(SpringMvcAnnotations.REQUEST_MAPPING)
+			.setConsumesProp(consumes)
+			.setProducesProp(produces)
+			.setMethodProp(method)
+			.setParamsProp(params)
+			.setScope("class", "method")
+			.setPathProps(pathProps);
+		mappingAnnotations.put(requestMapping.getAnnotationName(), requestMapping);
+
+		// @PostMapping
+		MappingAnnotation postMapping = this.createMapping(SpringMvcAnnotations.POST_MAPPING, Methods.POST.getValue(),
+				pathProps, consumes, produces, method, params);
+		mappingAnnotations.put(postMapping.getAnnotationName(), postMapping);
+
+		// @GetMapping
+		MappingAnnotation getMapping = this.createMapping(SpringMvcAnnotations.GET_MAPPING, Methods.GET.getValue(),
+				pathProps, consumes, produces, method, params);
+		mappingAnnotations.put(getMapping.getAnnotationName(), getMapping);
+
+		// @PutMapping
+		MappingAnnotation putMapping = this.createMapping(SpringMvcAnnotations.PUT_MAPPING, Methods.PUT.getValue(),
+				pathProps, consumes, produces, method, params);
+		mappingAnnotations.put(putMapping.getAnnotationName(), putMapping);
+
+		// @PatchMapping
+		MappingAnnotation patchMapping = this.createMapping(SpringMvcAnnotations.PATCH_MAPPING,
+				Methods.PATCH.getValue(), pathProps, consumes, produces, method, params);
+		mappingAnnotations.put(patchMapping.getAnnotationName(), patchMapping);
+
+		// @DeleteMapping
+		MappingAnnotation deleteMapping = this.createMapping(SpringMvcAnnotations.DELETE_MAPPING,
+				Methods.DELETE.getValue(), pathProps, consumes, produces, method, params);
+		mappingAnnotations.put(deleteMapping.getAnnotationName(), deleteMapping);
+
+		// @FeignClient
+		MappingAnnotation feignClient = MappingAnnotation.builder()
+			.setAnnotationName(DocGlobalConstants.FEIGN_CLIENT)
+			.setAnnotationFullyName(DocGlobalConstants.FEIGN_CLIENT_FULLY)
+			.setPathProps(DocAnnotationConstants.PATH_PROP);
+		mappingAnnotations.put(feignClient.getAnnotationName(), feignClient);
+
+		return mappingAnnotations;
+	}
+
+	/**
+	 * Helper method to create common HTTP method-based mappings
+	 * (e.g., @GetMapping, @PostMapping).
+	 * @param annotationName the annotation name
+	 * @param methodType the method type
+	 * @param pathProps the path properties
+	 * @param consumes the consumes property
+	 * @param produces the produces property
+	 * @param method the HTTP method
+	 * @param params the params property
+	 */
+	private MappingAnnotation createMapping(String annotationName, String methodType, String[] pathProps,
+			String consumes, String produces, String method, String params) {
+		return MappingAnnotation.builder()
+			.setAnnotationName(annotationName)
+			.setConsumesProp(consumes)
+			.setProducesProp(produces)
+			.setMethodProp(method)
+			.setParamsProp(params)
+			.setMethodType(methodType)
+			.setPathProps(pathProps);
 	}
 
 }

--- a/src/main/java/com/ly/doc/utils/JavaClassValidateUtil.java
+++ b/src/main/java/com/ly/doc/utils/JavaClassValidateUtil.java
@@ -1,7 +1,5 @@
 /*
- * smart-doc
- *
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,9 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.ly.doc.utils;
 
-import com.ly.doc.constants.*;
+import com.ly.doc.constants.DocAnnotationConstants;
+import com.ly.doc.constants.JSRAnnotationConstants;
+import com.ly.doc.constants.JavaTypeConstants;
+import com.ly.doc.constants.SolonAnnotations;
+import com.ly.doc.constants.SpringMvcAnnotations;
 import com.power.common.util.CollectionUtil;
 import com.power.common.util.StringUtil;
 import com.power.common.util.ValidateUtil;
@@ -227,7 +230,7 @@ public class JavaClassValidateUtil {
 	 * @return boolean
 	 */
 	public static boolean isIgnoreTag(String tagName) {
-		return tagName.equals("ignore");
+		return "ignore".equals(tagName);
 	}
 
 	/**
@@ -355,7 +358,7 @@ public class JavaClassValidateUtil {
 		switch (annotation) {
 			case SpringMvcAnnotations.SESSION_ATTRIBUTE:
 			case SpringMvcAnnotations.REQUEST_ATTRIBUTE:
-			case SpringMvcAnnotations.REQUEST_HERDER:
+			case SpringMvcAnnotations.REQUEST_HEADER:
 				return true;
 			default:
 				return false;


### PR DESCRIPTION


- Support the `path` attribute of `@FeignClient` for base URL configuration in API documentation.
- Refactor `SpringBootDocBuildTemplate` to extract mapping annotations into `buildSpringMappingAnnotations()` method for better maintainability.
- Add new constants in `DocAnnotationConstants`: `CONSUMES`, `PRODUCES`, `METHOD`, `PARAMS`, and `PATH_MAPPING_PROPS`.
- Deprecate misnamed `REQUEST_HERDER` and introduce correct `REQUEST_HEADER` in `SpringMvcAnnotations`.
- Update `SpringMVCRequestHeaderHandler` and `JavaClassValidateUtil` to use the new `REQUEST_HEADER` constant.
- Improve code consistency by using constants instead of string literals across annotation processing.
- Update copyright year to 2025 across relevant files.

Fixes #1114