### PR TITLE
fix(grpc): :bug: Fix gRPC doc generation for proto files organized in packages

### DIFF
--- a/src/main/java/com/ly/doc/model/grpc/ProtoInfo.java
+++ b/src/main/java/com/ly/doc/model/grpc/ProtoInfo.java
@@ -87,7 +87,7 @@ public class ProtoInfo implements Serializable {
 		String os = System.getProperty("os.name").toLowerCase();
 		String arch = System.getProperty("os.arch").toLowerCase();
 
-		log.info("The [os.name] is:" + os + ";[os.arch] is: " + arch);
+		log.info("The [os.name] is: " + os + " ; [os.arch] is: " + arch);
 
 		this.setTargetJsonDirectoryPath(targetJsonPath);
 		this.setJsonName("combined.json");


### PR DESCRIPTION
- Closes #1116

- Fixes the core issue: Resolves the problem where grpc-xxx goals fail when .proto files are organized using packages (e.g., base/enum.proto, file/fileops.proto). The root cause was an incorrect --proto_path calculation.
- Enhances path handling: Refactored getUniqueParentDirectories to correctly find the deepest common ancestor directory, ensuring --proto_path points to the actual root of the .proto files.
- Improves command robustness: Uses absolute paths for protoc, protoc-gen-doc, and all input .proto files to guarantee reliable execution across different environments.
- Adds comprehensive logging: Logs the final protoc command for debugging and adds [protoc] prefix to plugin output, making it easier to distinguish between smart-doc logs and protoc errors.