### PR TITLE
feat: add configurable operationId generation strategy

### DIFF
--- a/src/main/java/com/ly/doc/constants/OperationIdStrategyEnum.java
+++ b/src/main/java/com/ly/doc/constants/OperationIdStrategyEnum.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018-2025 smart-doc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ly.doc.constants;
+
+/**
+ * Enum representing the possible strategies for generating operationId in OpenAPI
+ * specifications. Each enum value defines a strategy for determining the value of
+ * `operationId` in the OpenAPI document.
+ *
+ * <p>
+ * Supported strategies include:
+ * <ul>
+ * <li>Using the method name only</li>
+ * <li>Using the methodId (MD5 hash)</li>
+ * <li>Using path + method name + HTTP method type</li>
+ * </ul>
+ *
+ * @author smart-doc
+ * @version 3.1.2
+ */
+public enum OperationIdStrategyEnum {
+
+	/**
+	 * Use the method name only as the operationId.
+	 * <p>
+	 * This is the default strategy. The operationId will be the Java method name.
+	 * If there are duplicate method names, a numeric suffix will be added.
+	 * </p>
+	 * <p>
+	 * Example: {@code getUserInfo} or {@code getUserInfo_1} for duplicates
+	 * </p>
+	 */
+	METHOD_NAME,
+
+	/**
+	 * Use the methodId (MD5 hash) as the operationId.
+	 * <p>
+	 * The methodId is generated as an MD5 hash based on the class name, method name, and order.
+	 * This ensures unique operationIds across the entire API.
+	 * </p>
+	 * <p>
+	 * Example: {@code user-controller-getUserInfo-1-a1b2c3d4e5f6}
+	 * </p>
+	 */
+	METHOD_ID,
+
+	/**
+	 * Use path + method name + HTTP method type as the operationId.
+	 * <p>
+	 * This strategy combines URL path segments (excluding path variables), the method name,
+	 * and the HTTP method type to create a descriptive operationId.
+	 * </p>
+	 * <p>
+	 * Example: For a POST request to {@code /api/users/profile} with method {@code updateProfile},
+	 * the operationId will be {@code api-users-updateProfile-POST}
+	 * </p>
+	 */
+	PATH_METHOD_HTTP;
+
+}

--- a/src/main/java/com/ly/doc/model/ApiConfig.java
+++ b/src/main/java/com/ly/doc/model/ApiConfig.java
@@ -24,6 +24,7 @@ package com.ly.doc.model;
 import com.ly.doc.constants.ComponentTypeEnum;
 import com.ly.doc.constants.DocLanguage;
 import com.ly.doc.constants.OpenApiTagNameTypeEnum;
+import com.ly.doc.constants.OperationIdStrategyEnum;
 import com.ly.doc.handler.ICustomJavaMethodHandler;
 import com.ly.doc.model.jmeter.JMeter;
 import com.ly.doc.model.rpc.RpcApiDependency;
@@ -502,6 +503,31 @@ public class ApiConfig {
 	 * @since 3.1.0
 	 */
 	private boolean allowSelfReference = Boolean.FALSE;
+
+	/**
+	 * Strategy for generating OpenAPI operationId.
+	 * <p>
+	 * This field specifies how the operationId in the generated OpenAPI document is
+	 * determined. Supported strategies include:
+	 * </p>
+	 *
+	 * <ul>
+	 * <li>{@link OperationIdStrategyEnum#METHOD_NAME}: Use the method name only
+	 * (with numeric suffix for duplicates)</li>
+	 * <li>{@link OperationIdStrategyEnum#METHOD_ID}: Use the methodId (MD5 hash)</li>
+	 * <li>{@link OperationIdStrategyEnum#PATH_METHOD_HTTP}: Use path + method name +
+	 * HTTP method type</li>
+	 * </ul>
+	 *
+	 * <p>
+	 * This setting affects how API operations are identified in the OpenAPI documentation.
+	 * Choose the strategy that best aligns with your API naming conventions.
+	 * </p>
+	 *
+	 * @see OperationIdStrategyEnum
+	 * @since 3.1.2
+	 */
+	private OperationIdStrategyEnum operationIdStrategy = OperationIdStrategyEnum.METHOD_NAME;
 
 	public static ApiConfig getInstance() {
 		return instance;
@@ -1209,6 +1235,18 @@ public class ApiConfig {
 
 	public ApiConfig setOpenApiTagNameType(OpenApiTagNameTypeEnum openApiTagNameType) {
 		this.openApiTagNameType = openApiTagNameType;
+		return this;
+	}
+
+	public OperationIdStrategyEnum getOperationIdStrategy() {
+		if (Objects.isNull(operationIdStrategy)) {
+			return OperationIdStrategyEnum.METHOD_NAME;
+		}
+		return operationIdStrategy;
+	}
+
+	public ApiConfig setOperationIdStrategy(OperationIdStrategyEnum operationIdStrategy) {
+		this.operationIdStrategy = operationIdStrategy;
 		return this;
 	}
 


### PR DESCRIPTION
## Summary
  This PR adds a configurable operationId generation strategy to allow users to choose different formats for
  operationId in the generated OpenAPI documentation.

  ## Motivation
  After commit b279aa6f, the operationId was changed from methodId (e.g., `athena-machine-getGuarderToken-POST`)
  to method name only (e.g., `openRoomAndUploadNextSection`). This PR provides a configuration option to support
  multiple strategies.

  ## Changes
  - Add `OperationIdStrategyEnum` with three strategies:
    - `METHOD_NAME`: Use the method name only (default, with duplicate handling)
    - `METHOD_ID`: Use the methodId (MD5 hash)
    - `PATH_METHOD_HTTP`: Use path + method name + HTTP method type
  - Add `operationIdStrategy` configuration field in `ApiConfig`
  - Update `OpenApiBuilder` to implement the strategy logic
  - Maintain backward compatibility with `METHOD_NAME` as default

  ## Usage Example
  In `smart-doc.json`:
  ```json
  {
    "operationIdStrategy": "PATH_METHOD_HTTP"
  }

  Examples

  - METHOD_NAME: getUserInfo or getUserInfo_1 for duplicates
  - METHOD_ID: user-controller-getUserInfo-1-a1b2c3d4e5f6
  - PATH_METHOD_HTTP: api-users-updateProfile-POST