### PR TITLE
fix: :bug: correct media type handling for `@DeleteMapping` with `@RequestBody`

### DIFF
--- a/src/main/java/com/ly/doc/template/IRestDocTemplate.java
+++ b/src/main/java/com/ly/doc/template/IRestDocTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -1110,8 +1110,7 @@ public interface IRestDocTemplate extends IBaseDocBuildTemplate {
 				required = Boolean.parseBoolean(strRequired);
 			}
 			// not get and delete method and has MediaType
-			boolean bodyMediaType = !(Methods.GET.getValue().equals(docJavaMethod.getMethodType())
-					|| Methods.DELETE.getValue().equals(docJavaMethod.getMethodType()))
+			boolean bodyMediaType = !Methods.GET.getValue().equals(docJavaMethod.getMethodType())
 					&& StringUtil.isNotEmpty(methodMediaType)
 					&& (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(methodMediaType)
 							|| MediaType.APPLICATION_JSON_VALUE.equals(methodMediaType)

--- a/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/SpringBootDocBuildTemplate.java
@@ -163,7 +163,7 @@ public class SpringBootDocBuildTemplate implements IDocBuildTemplate<ApiDoc>, IW
 		annotations.setServerEndpointAnnotation(serverEndpointAnnotation);
 
 		// add mapping annotations
-		Map<String, MappingAnnotation> mappingAnnotations = buildSpringMappingAnnotations();
+		Map<String, MappingAnnotation> mappingAnnotations = this.buildSpringMappingAnnotations();
 		annotations.setMappingAnnotations(mappingAnnotations);
 
 		// Exception advice annotations

--- a/src/main/java/com/ly/doc/utils/ApiParamTreeUtil.java
+++ b/src/main/java/com/ly/doc/utils/ApiParamTreeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 smart-doc
+ * Copyright (C) 2018-2025 smart-doc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -129,8 +129,7 @@ public class ApiParamTreeUtil {
 				param.setId(pathParams.size() + 1);
 				pathParams.add(param);
 			}
-			else if (param.isQueryParam() || Methods.GET.getValue().equals(methodType)
-					|| Methods.DELETE.getValue().equals(methodType)) {
+			else if (param.isQueryParam() || Methods.GET.getValue().equals(methodType)) {
 				if (queryReqParamMap.containsKey(param.getField())) {
 					param.setConfigParam(true).setValue(queryReqParamMap.get(param.getField()).getValue());
 				}


### PR DESCRIPTION

- Closes  #1133
- Remove redundant DELETE method check in bodyMediaType logic, which caused incorrect OpenAPI spec generation when `@DeleteMapping` is used with `@RequestBody`
- Simplify query parameter handling by removing unnecessary DELETE-specific condition
- Update copyright year from 2024 to 2025 in affected files